### PR TITLE
Fix: Playwright e2e helpers - Response body handling

### DIFF
--- a/lib/generators/cypress_on_rails/templates/spec/playwright/support/on-rails.js
+++ b/lib/generators/cypress_on_rails/templates/spec/playwright/support/on-rails.js
@@ -8,7 +8,7 @@ const appCommands = async (data) => {
   const response = await context.post('/__e2e__/command', { data })
 
   expect(response.ok()).toBeTruthy()
-  return response.body
+  return response.json();
 }
 
 const app = (name, options = {}) => appCommands({ name, options }).then((body) => body[0])
@@ -23,7 +23,7 @@ const appVcrInsertCassette = async (cassette_name, options) => {
   Object.keys(options).forEach(key => options[key] === undefined ? delete options[key] : {});
   const response = await context.post("/__e2e__/vcr/insert", {data: [cassette_name,options]});
   expect(response.ok()).toBeTruthy();
-  return response.body;
+  return response.json();
 }
 
 const appVcrEjectCassette = async () => {
@@ -31,7 +31,7 @@ const appVcrEjectCassette = async () => {
 
   const response = await context.post("/__e2e__/vcr/eject");
   expect(response.ok()).toBeTruthy();
-  return response.body;
+  return response.json();
 }
 
 export { appCommands, app, appScenario, appEval, appFactories, appVcrInsertCassette, appVcrEjectCassette }

--- a/specs_e2e/rails_4_2/Gemfile
+++ b/specs_e2e/rails_4_2/Gemfile
@@ -3,6 +3,9 @@ source 'https://rubygems.org'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 4.2.10'
 gem 'sprockets', '~> 3.7.2'
+# Solution for issue: NoMethodError: undefined method `new' for BigDecimal:Class
+# https://github.com/ruby/bigdecimal?tab=readme-ov-file#which-version-should-you-select
+gem 'bigdecimal', '1.3.5'
 
 group :development, :test do
   gem 'vcr'


### PR DESCRIPTION
Replace `response.body` calls of Playwright e2e command helpers with [response.json()](https://playwright.dev/docs/api/class-apiresponse#api-response-json), so the parsed JSON response can be used instead of getting a  Buffer object.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced response handling in asynchronous functions to return parsed JSON data for improved data management.
	- Added a new dependency (`bigdecimal` gem) to address specific method errors in the Ruby on Rails project.

- **Bug Fixes**
	- Resolved issues related to raw response handling, ensuring more reliable data processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->