### PR TITLE
Change rails server with test environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,24 +117,6 @@ If you are not using `factory_bot` look at `e2e/cypress/app_commands/factory_bot
 
 Now you can create scenarios and commands that are plain Ruby files that get loaded through middleware, the ruby sky is your limit.
 
-### Update your database.yml
-
-When writing and running tests on your local computer, it's recommended to start your server in development mode so that changes you
-make are picked up without having to restart your local server.
-
-It's recommended you update your `database.yml` to check if the `CYPRESS` environment variable is set and switch it to the test database
-otherwise, cypress will keep clearing your development database.
-
-For example:
-```yaml
-development:
-  <<: *default
-  database: <%= ENV['CYPRESS'] ? 'my_db_test' : 'my_db_development' %>
-test:
-  <<: *default
-  database: my_db_test
-```
-
 ### WARNING
 *WARNING!!:* cypress-on-rails can execute arbitrary ruby code
 Please use with extra caution if starting your local server on 0.0.0.0 or running the gem on a hosted server
@@ -144,8 +126,8 @@ Please use with extra caution if starting your local server on 0.0.0.0 or runnin
 Getting started on your local environment
 
 ```shell
-# start rails
-CYPRESS=1 bin/rails server -p 5017
+# start rails with test environment
+CYPRESS=1 RAILS_ENV=test bin/rails server -p 5017
 
 # in separate window start cypress
 yarn cypress open --project ./e2e

--- a/README.md
+++ b/README.md
@@ -117,6 +117,14 @@ If you are not using `factory_bot` look at `e2e/cypress/app_commands/factory_bot
 
 Now you can create scenarios and commands that are plain Ruby files that get loaded through middleware, the ruby sky is your limit.
 
+## If you want to use live reload from rails
+
+Change the below setting in test.rb
+
+```ruby
+config.enable_reloading = ENV['CYPRESS'].present?
+```
+
 ### WARNING
 *WARNING!!:* cypress-on-rails can execute arbitrary ruby code
 Please use with extra caution if starting your local server on 0.0.0.0 or running the gem on a hosted server

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ Change the below setting in test.rb
 
 ```ruby
 config.enable_reloading = ENV['CYPRESS'].present?
+...
+config.action_controller.allow_forgery_protection = ENV["CYPRESS"].present?
 ```
 
 ### WARNING
@@ -133,6 +135,7 @@ Please use with extra caution if starting your local server on 0.0.0.0 or runnin
 
 Getting started on your local environment
 
+Also anywhere in configuartion, if port `3000` exists, simply add ENV['CYPRESS'].present? ? `5017` : `3000`
 ```shell
 # start rails with test environment
 CYPRESS=1 RAILS_ENV=test bin/rails server -p 5017


### PR DESCRIPTION
If there is a reason why it should be running in development mode, just let me know :D with RAILS_ENV=test it will just run with test database

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Removed outdated local test database setup guidance.
  - Added instructions for enabling live-reload in the test environment to improve iterative testing.
  - Noted an optional port override when the default port is in use.
  - Clarified the recommended command to start the server in the test environment for running end-to-end tests.
  - Retained existing warnings about running on certain hosts/configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->