### PR TITLE
update JetBrains logo to new brand assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,8 +597,8 @@ In `config/initializers/cypress_on_rails.rb`, add this line:
 
 ## Supporters
 
-<a href="https://www.jetbrains.com">
-  <img src="https://user-images.githubusercontent.com/4244251/184881139-42e4076b-024b-4b30-8c60-c3cd0e758c0a.png" alt="JetBrains" height="120px">
+<a href="https://jb.gg/OpenSource" style="margin-right: 20px;">
+  <img src="https://resources.jetbrains.com/storage/products/company/brand/logos/jetbrains.png" alt="JetBrains" height="120px">
 </a>
 <a href="https://scoutapp.com">
   <picture>


### PR DESCRIPTION
- Replace old GitHub-hosted JetBrains logo with new official brand assets
- Update link to point to JetBrains OpenSource page as recommended

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the JetBrains supporter badge in the README.
    * Link now points to https://jb.gg/OpenSource.
    * Added spacing to the badge for improved layout.
    * Replaced the image with JetBrains’ official brand logo URL.
  * No other supporter entries were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->