### PR TITLE
Fix some minor typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,7 +161,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 [Compare]: https://github.com/shakacode/cypress-playwright-on-rails/compare/v1.7.0...v1.8.0
 
 ### Changed
-* Use `FactoryBo#reload` to reset FactoryBot
+* Use `FactoryBot#reload` to reset FactoryBot
 
 ---
 

--- a/lib/generators/cypress_on_rails/templates/spec/cypress/e2e/rails_examples/using_factory_bot.cy.js
+++ b/lib/generators/cypress_on_rails/templates/spec/cypress/e2e/rails_examples/using_factory_bot.cy.js
@@ -9,7 +9,7 @@ describe('Rails using factory bot examples', function() {
     ])
     cy.visit('/')
     cy.get('table').find('tbody').should(($tbody) => {
-      // clean should of removed these from other tests
+      // clean should have removed these from other tests
       expect($tbody).not.to.contain('Hello World')
 
       expect($tbody).to.contain('Good bye Mars')
@@ -23,7 +23,7 @@ describe('Rails using factory bot examples', function() {
     ])
     cy.visit('/')
     cy.get('table').find('tbody').should(($tbody) => {
-      // clean should of removed these from other tests
+      // clean should have removed these from other tests
       expect($tbody).to.contain('Hello World')
       expect($tbody).not.to.contain('Good bye Mars')
     })

--- a/lib/generators/cypress_on_rails/templates/spec/cypress/e2e/rails_examples/using_scenarios.cy.js
+++ b/lib/generators/cypress_on_rails/templates/spec/cypress/e2e/rails_examples/using_scenarios.cy.js
@@ -7,7 +7,7 @@ describe('Rails using scenarios examples', function() {
     cy.appScenario('basic')
     cy.visit('/')
     cy.get('table').find('tbody').should(($tbody) => {
-      // clean should of removed these from other tests
+      // clean should have removed these from other tests
       expect($tbody).not.to.contain('Good bye Mars')
       expect($tbody).not.to.contain('Hello World')
 

--- a/lib/generators/cypress_on_rails/templates/spec/cypress/support/on-rails.js
+++ b/lib/generators/cypress_on_rails/templates/spec/cypress/support/on-rails.js
@@ -1,4 +1,4 @@
-// CypressOnRails: dont remove these command
+// CypressOnRails: don't remove these commands
 Cypress.Commands.add('appCommands', function (body) {
   Object.keys(body).forEach(key => body[key] === undefined ? delete body[key] : {});
   const log = Cypress.log({ name: "APP", message: body, autoEnd: false })


### PR DESCRIPTION
I fixed some minor typos in some of the comments and doc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Corrected class name reference in the changelog and improved grammar.
- Tests
  - Cleaned up comment text in Cypress E2E templates; no changes to test behavior.
- Style
  - Fixed minor typos in internal comments for clarity; no runtime or functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->