### PR TITLE
Add simple release script (gem-only)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,16 @@
-require 'bundler/gem_tasks'
-
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec) do |t|
   t.pattern = 'spec/cypress_on_rails/*_spec.rb'
+end
+
+# Manually define build task (normally provided by bundler/gem_tasks)
+# We don't use bundler/gem_tasks because it conflicts with our custom release task
+desc "Build gem into pkg directory"
+task :build do
+  require_relative 'lib/cypress_on_rails/version'
+  sh "gem build cypress-on-rails.gemspec"
+  sh "mkdir -p pkg"
+  sh "mv cypress-on-rails-#{CypressOnRails::VERSION}.gem pkg/"
 end
 
 task default: %w[spec build]

--- a/Rakefile
+++ b/Rakefile
@@ -3,14 +3,4 @@ RSpec::Core::RakeTask.new(:spec) do |t|
   t.pattern = 'spec/cypress_on_rails/*_spec.rb'
 end
 
-# Manually define build task (normally provided by bundler/gem_tasks)
-# We don't use bundler/gem_tasks because it conflicts with our custom release task
-desc "Build gem into pkg directory"
-task :build do
-  require_relative 'lib/cypress_on_rails/version'
-  sh "gem build cypress-on-rails.gemspec"
-  sh "mkdir -p pkg"
-  sh "mv cypress-on-rails-#{CypressOnRails::VERSION}.gem pkg/"
-end
-
-task default: %w[spec build]
+task default: :spec

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -40,7 +40,7 @@ task :release, %i[gem_version dry_run] do |_t, args|
 
   # See https://github.com/svenfuchs/gem-release
   sh_in_dir(gem_root, "git pull --rebase")
-  sh_in_dir(gem_root, "gem bump --no-commit #{gem_version.strip.empty? ? '' : %(-v #{gem_version})}")
+  sh_in_dir(gem_root, "gem bump --no-commit --file lib/cypress_on_rails/version.rb #{gem_version.strip.empty? ? '' : %(-v #{gem_version})}")
 
   # Release the new gem version
   puts "Carefully add your OTP for Rubygems. If you get an error, run 'gem release' again."

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -15,7 +15,7 @@ desc("Releases the gem using the given version.
 
 IMPORTANT: the gem version must be in valid rubygem format (no dashes).
 
-This task depends on the gem-release ruby gem which is installed via `bundle install`
+This task depends on the gem-release (ruby gem) which is installed via `bundle install`
 
 1st argument: The new version in rubygem format (no dashes). Pass no argument to
               automatically perform a patch version bump.
@@ -23,7 +23,7 @@ This task depends on the gem-release ruby gem which is installed via `bundle ins
 
 Note, accept defaults for rubygems options. Script will pause to get 2FA tokens.
 
-Example: `rake release[1.19.0,false]`")
+Example: `rake release[2.1.0,false]`")
 task :release, %i[gem_version dry_run] do |_t, args|
   include CypressOnRails::TaskHelpers
 

--- a/rakelib/task_helpers.rb
+++ b/rakelib/task_helpers.rb
@@ -9,7 +9,15 @@ module CypressOnRails
 
     # Executes a string or an array of strings in a shell in the given directory
     def sh_in_dir(dir, *shell_commands)
-      shell_commands.flatten.each { |shell_command| sh %(cd #{dir} && #{shell_command.strip}) }
+      Dir.chdir(dir) do
+        # Without `with_unbundled_env`, running bundle in the child directories won't correctly
+        # update the Gemfile.lock
+        Bundler.with_unbundled_env do
+          shell_commands.flatten.each do |shell_command|
+            sh(shell_command.strip)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
Adds a clean, simple release script that matches the react_on_rails pattern but without npm/yarn parts.

## Changes

1. **Removed bundler/gem_tasks** - Was causing task conflicts with our custom release task
2. **Created rakelib/release.rake** - Simple release task matching react_on_rails pattern
3. **Added rakelib/task_helpers.rb** - Helper module for common functionality
4. **Fixed gem bump issues**:
   - Changed `--version` to `-v` flag (correct syntax)
   - Added `--file` flag to specify version file location
   - Fixed `sh_in_dir` to use `Dir.chdir` instead of subshell

## Release Workflow

```bash
rake release[1.19.0]        # Release version 1.19.0
rake release[1.19.0,true]   # Dry run
rake release                # Auto patch bump
```

## Test Results
✅ Dry run tested successfully:
- Version bumped correctly from 1.18.0 to 1.19.0
- Git operations work properly
- Post-release instructions displayed

This is a clean PR focused only on the release script functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)