### PR TITLE
Fix release task to commit version bump before gem release (#???)

### DIFF
--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -51,7 +51,7 @@ task :release, %i[gem_version dry_run] do |_t, args|
 
   unless is_dry_run
     # Commit the version bump and Gemfile.lock update
-    sh_in_dir(gem_root, "git add -A")
+    sh_in_dir(gem_root, "git add lib/cypress_on_rails/version.rb Gemfile.lock")
     sh_in_dir(gem_root, "git commit -m \"Release v#{actual_version}\"")
 
     # Tag the release

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -43,7 +43,7 @@ task :release, %i[gem_version dry_run] do |_t, args|
   sh_in_dir(gem_root, "gem bump --no-commit --file lib/cypress_on_rails/version.rb #{gem_version.strip.empty? ? '' : %(--version #{gem_version})}")
 
   # Read the actual version from the file after bump
-  require_relative "../lib/cypress_on_rails/version"
+  load File.expand_path("../lib/cypress_on_rails/version.rb", __dir__)
   actual_version = CypressOnRails::VERSION
 
   # Update Gemfile.lock files


### PR DESCRIPTION
## Summary
- Fixed the release rake task to properly handle the entire release workflow
- Aligned the implementation with react_on_rails pattern for consistency
- Task now commits version changes, creates tags, and pushes automatically

## Problems Fixed

### 1. Immediate Issue
The release script was failing with "Uncommitted changes found" because:
- `gem bump --no-commit` modifies `lib/cypress_on_rails/version.rb`
- `gem release` expects a clean working directory and aborts if there are uncommitted changes

### 2. Design Issues
- The actual version wasn't captured for automatic patch bumps
- Dry-run mode wasn't respected for git operations
- No automatic tagging or pushing was happening
- Gemfile.lock wasn't being updated

## Solution
Updated the release task to match the react_on_rails pattern:
1. Bump version with `gem bump --no-commit`
2. Read the actual version from the file (handles auto-patch bumps)
3. Run `bundle install` to update Gemfile.lock
4. Commit all changes together (version + Gemfile.lock)
5. Create a git tag for the release
6. Push commit and tags to repository
7. Run `gem release` to publish

All git operations respect the dry-run flag.

## Testing
The release task should now complete successfully without manual intervention.

## Note
The RELEASING.md documentation references `release:prepare` and `release:publish` tasks that don't exist. This should be addressed in a follow-up PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Simplified release instructions to a single command with an optional dry-run.
  - Updated pre-/post-release and rollback guidance to match the unified workflow.
  - Removed legacy multi-step directions and outdated error sections.

- Chores
  - Streamlined release task to automate version bumping, lockfile updates, commit/tag creation, pushing, and publishing in one flow.
  - Improved dry-run output to clearly describe intended actions without making changes.
  - Ensured consistent tagging and clearer messaging during the release process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->