### PR TITLE
Fix release task to not commit ignored Gemfile.lock (#196)

### DIFF
--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -50,8 +50,8 @@ task :release, %i[gem_version dry_run] do |_t, args|
   sh_in_dir(gem_root, "bundle install")
 
   unless is_dry_run
-    # Commit the version bump and Gemfile.lock update
-    sh_in_dir(gem_root, "git add lib/cypress_on_rails/version.rb Gemfile.lock")
+    # Commit the version bump
+    sh_in_dir(gem_root, "git add lib/cypress_on_rails/version.rb")
     sh_in_dir(gem_root, "git commit -m \"Release v#{actual_version}\"")
 
     # Tag the release


### PR DESCRIPTION
## Summary
- Removed `Gemfile.lock` from the git add command in the release task since it's properly gitignored for gem projects

## Details
The release task was failing because it tried to add `Gemfile.lock`, which is in `.gitignore`. For gem libraries (vs applications), `Gemfile.lock` should not be committed as gems need to work with a range of dependency versions, not locked versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)