### PR TITLE
Update gem description to include Playwright support

### DIFF
--- a/cypress-on-rails.gemspec
+++ b/cypress-on-rails.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |s|
   s.author      = ["miceportal team", 'Grant Petersen-Speelman']
   s.email       = ["info@miceportal.de", 'grantspeelman@gmail.com']
   s.homepage    = "http://github.com/shakacode/cypress-on-rails"
-  s.summary     = "Integrates cypress with rails or rack applications"
-  s.description = "Integrates cypress with rails or rack applications"
+  s.summary     = "Integrates Cypress and Playwright with Rails or Rack applications"
+  s.description = "Integrates Cypress and Playwright with Rails or Rack applications"
   s.post_install_message = 'The CypressDev constant is being deprecated and will be completely removed and replaced with CypressOnRails.'
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {spec}/*`.split("\n")


### PR DESCRIPTION
## Summary
- Updated gemspec summary and description to mention both Cypress and Playwright
- This accurately reflects the gem's current capabilities as Playwright support has been available

## Context
The gem has supported Playwright for a while, but the RubyGems description still only mentioned Cypress. This update improves discoverability for users searching for Playwright + Rails solutions.

## Changes
- Updated `s.summary` to "Integrates Cypress and Playwright with Rails or Rack applications"
- Updated `s.description` to "Integrates Cypress and Playwright with Rails or Rack applications"

This change will appear on RubyGems with the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)