### PR TITLE
Fix install_folder path in generator (#201)

### DIFF
--- a/lib/generators/cypress_on_rails/templates/config/initializers/cypress_on_rails.rb.erb
+++ b/lib/generators/cypress_on_rails/templates/config/initializers/cypress_on_rails.rb.erb
@@ -1,7 +1,7 @@
 if defined?(CypressOnRails)
   CypressOnRails.configure do |c|
     c.api_prefix = "<%= options.api_prefix %>"
-    c.install_folder = File.expand_path("#{__dir__}/../../<%= options.install_folder %>/<%= options.framework %>")
+    c.install_folder = File.expand_path("#{__dir__}/../../<%= options.install_folder %>")
     # WARNING!! CypressOnRails can execute arbitrary ruby code
     # please use with extra caution if enabling on hosted servers or starting your local server on 0.0.0.0
     c.use_middleware = !Rails.env.production?


### PR DESCRIPTION
## Summary
- Fixed the `install_folder` path in the generator's initializer template to point to the install directory (e.g., `e2e`) instead of the framework subdirectory (e.g., `e2e/cypress`)
- This allows Cypress/Playwright to correctly find their config files after running the install generator

## Problem
After running `bin/rails g cypress_on_rails:install`, the generated initializer had:
```ruby
c.install_folder = File.expand_path("#{__dir__}/../../e2e/cypress")
```

But the actual file structure created is:
```
e2e/
  cypress.config.js      # Config file at e2e level
  cypress/               # Cypress directory
    support/
    e2e/
```

This caused Cypress to fail finding the config file since it expects the config to be in the same directory as the `install_folder` setting.

## Solution
Changed the template to:
```ruby
c.install_folder = File.expand_path("#{__dir__}/../../e2e")
```

Now `install_folder` correctly points to where the config file lives.

## Test plan
- [ ] Run the generator on a fresh Rails app and verify Cypress can find its config
- [ ] Verify the fix works for both Cypress and Playwright frameworks

Fixes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the install directory resolution for Cypress on Rails to use only the configured install folder. Generated files now appear in the expected location without an extra framework subfolder, improving consistency across environments and reducing path-related confusion during setup and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->