### PR TITLE
Remove Rails Autoscale and Reviewable sponsor images from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -777,14 +777,8 @@ In `config/initializers/cypress_on_rails.rb`, add this line:
     <img alt="BrowserStack" src="https://user-images.githubusercontent.com/4244251/184881129-e1edf4b7-3ae1-4ea8-9e6d-3595cf01609e.png" height="55px">
   </picture>
 </a>
-<a href="https://railsautoscale.com">
-  <img src="https://user-images.githubusercontent.com/4244251/184881144-95c2c25c-9879-4069-864d-4e67d6ed39d2.png" alt="Rails Autoscale" height="55px">
-</a>
 <a href="https://www.honeybadger.io">
   <img src="https://user-images.githubusercontent.com/4244251/184881133-79ee9c3c-8165-4852-958e-31687b9536f4.png" alt="Honeybadger" height="55px">
-</a>
-<a href="https://reviewable.io">
-  <img src="https://user-images.githubusercontent.com/20628911/230848305-c94510a4-82d7-468f-bf9f-eeb81d3f2ce0.png" alt="Reviewable" height="55px">
 </a>
 
 <br />


### PR DESCRIPTION
This PR removes the Rails Autoscale and Reviewable sponsor images and links from the README, consistent with changes made across other ShakaCode repositories.

Related commits:
- shakapacker: https://github.com/shakacode/shakapacker/commit/8ce87ebb826a299e801bd7bcfd41608d25a2ed1c
- react_on_rails: https://github.com/shakacode/react_on_rails/commit/5edfa628

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed two sponsor badges from the README, along with their associated links.
  * Streamlined the README header for a cleaner presentation.
  * Reduced external outbound links in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->