### PR TITLE
style: remove extra spaces from the generated files

### DIFF
--- a/lib/generators/cypress_on_rails/templates/config/initializers/cypress_on_rails.rb.erb
+++ b/lib/generators/cypress_on_rails/templates/config/initializers/cypress_on_rails.rb.erb
@@ -15,12 +15,12 @@ if defined?(CypressOnRails)
     <% unless options.experimental %># <% end %>   cassette_library_dir: File.expand_path("#{__dir__}/../../<%= options.install_folder %>/fixtures/vcr_cassettes")
     <% unless options.experimental %># <% end %> }
     c.logger = Rails.logger
-    
+
     # Server configuration for rake tasks (cypress:open, cypress:run, playwright:open, playwright:run)
     # c.server_host = 'localhost'  # or use ENV['CYPRESS_RAILS_HOST']
-    # c.server_port = 3001         # or use ENV['CYPRESS_RAILS_PORT']  
+    # c.server_port = 3001         # or use ENV['CYPRESS_RAILS_PORT']
     # c.transactional_server = true  # Enable automatic transaction rollback between tests
-    
+
     # Server lifecycle hooks for rake tasks
     # c.before_server_start = -> { DatabaseCleaner.clean_with(:truncation) }
     # c.after_server_start = -> { puts "Test server started on port #{CypressOnRails.configuration.server_port}" }

--- a/lib/generators/cypress_on_rails/templates/spec/e2e/e2e_helper.rb.erb
+++ b/lib/generators/cypress_on_rails/templates/spec/e2e/e2e_helper.rb.erb
@@ -29,10 +29,10 @@ factory = FactoryBot if defined?(FactoryBot)
 factory = FactoryGirl if defined?(FactoryGirl)
 
 CypressOnRails::SmartFactoryWrapper.configure(
-    always_reload: false,
-    factory: factory,
-    files: [
-      Rails.root.join('spec', 'factories.rb'),
-      Rails.root.join('spec', 'factories', '**', '*.rb')
-    ]
+  always_reload: false,
+  factory: factory,
+  files: [
+    Rails.root.join('spec', 'factories.rb'),
+    Rails.root.join('spec', 'factories', '**', '*.rb')
+  ]
 )


### PR DESCRIPTION
- Follows up #179 and https://github.com/shakacode/cypress-playwright-on-rails/commit/2e013d94e20eda1da78f3bef7ccd83f8a3578245#diff-4625bb0f6be3515275f74d2046e0bb723de0604a63046a770a1bc6e346da0287R26-R29

## Why

In a newly-created rails app codebase, developers would get RuboCop offenses as follow:

```
$ rails new xyz && cd xyz
$ bundle add cypress-on-rails
$ bundle exec rails g cypress_on_rails:install
$ bundle exec rubocop
Inspecting 31 files
................C..............

Offenses:

config/initializers/cypress_on_rails.rb:18:1: C: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
config/initializers/cypress_on_rails.rb:21:70: C: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
    # c.server_port = 3001         # or use ENV['CYPRESS_RAILS_PORT']  
                                                                     ^^
config/initializers/cypress_on_rails.rb:23:1: C: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.

31 files inspected, 3 offenses detected, 3 offenses autocorrectable
takuya.noguchi@t cog % bundle exec rubocop e2e/e2e_helper.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
```

While no warnings in `spec/e2e/e2e_helper.rb.erb` with the `rubocop-rails-omakase`, the default RuboCop configuration as of 2025, we should pay attention to `spec/e2e/e2e_helper.rb.erb` (`Layout/*Indentation` cops at least) as well.

```
$ bundle exec rubocop e2e/e2e_helper.rb
Inspecting 1 file
C

Offenses:

e2e/e2e_helper.rb:1:1: C: [Correctable] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
# This is loaded once before the first command is executed
^
e2e/e2e_helper.rb:32:5: C: [Correctable] Layout/FirstArgumentIndentation: Indent the first argument one step more than the start of the previous line.
    always_reload: false, ...
    ^^^^^^^^^^^^^^^^^^^^^
e2e/e2e_helper.rb:38:1: C: [Correctable] Layout/ClosingParenthesisIndentation: Indent ) to column 2 (not 0)
)
^

1 file inspected, 3 offenses detected, 3 offenses autocorrectable
```

You would say `Style/FrozenStringLiteralComment` can be ignored.

## Changes

- Removes extra spaces from the generator template files to remove them from the generated files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated code formatting and indentation in configuration and test helper templates for improved consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->