### PR TITLE
Fix Rails 8.1 compatibility issue (#202)

### DIFF
--- a/lib/cypress_on_rails/railtie.rb
+++ b/lib/cypress_on_rails/railtie.rb
@@ -1,3 +1,4 @@
+require 'active_support/core_ext/module/delegation'
 require 'rails/railtie'
 require 'cypress_on_rails/configuration'
 


### PR DESCRIPTION
## Summary
- Fixed `NoMethodError: undefined method 'delegate_missing_to'` error in Rails 8.1
- Added `require 'active_support/core_ext/module/delegation'` before requiring `rails/railtie`

## Details
Rails 8.1.0's railties now uses `delegate_missing_to` in `Rails::Initializable::Collection`, which requires ActiveSupport's delegation extensions to be loaded first. Without this, the railtie spec fails with a NoMethodError.

## Test plan
- [x] Tests pass locally with `bundle exec rake`
- [x] CI tests should now pass for Rails 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to support module delegation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->