### PR TITLE
Do not override RAILS_ENV variable if already defined

### DIFF
--- a/lib/cypress_on_rails/server.rb
+++ b/lib/cypress_on_rails/server.rb
@@ -69,7 +69,7 @@ module CypressOnRails
       run_hook(config.before_server_start)
       
       ENV['CYPRESS'] = '1'
-      ENV['RAILS_ENV'] = 'test'
+      ENV['RAILS_ENV'] ||= 'test'
       
       server_pid = spawn_server
       


### PR DESCRIPTION
This PR has a small change to allow using a different Rails environment for the server started by Cypress.

The reason for this is that it's common to have some things disabled for unit tests when running in the `test` environment and we don't want to disable them for the e2e tests. I know something could be achieved in some cases using the `ENV["CYPRESS"]` env variable, but that would only apply for code that runs after that env variable is set. If we want to add some gem only when running e2e tests and not for other tests we can't do this currently.

With this change we could have gems in an `e2e` group when needed, and then run `RAILS_ENV=e2e rails cypress:run`.


More context:

I found this issue with this sample app https://github.com/fastruby/coverage-with-cypress-sample-app. I'm using Coverband to calculate the Ruby code coverage after running the Cypress tests, but since it runs in the `test` environment, Coverband is also initialized for the `rails test` Minitest test suite and an error shows up at the end:

```
E, [2026-01-02T16:29:34.221521 #322239] ERROR -- : coverage failed to store
E, [2026-01-02T16:29:34.221579 #322239] ERROR -- : Coverband Error: #<RuntimeError: coverage measurement is not enabled> coverage measurement is not enabled
```

With the change of this PR, I can add the coverband gem in an `e2e` group so it works properly without being loaded for minitest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed server initialization to respect pre-existing RAILS_ENV configuration instead of unconditionally overriding it, allowing users to specify their preferred environment settings during startup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->