### PR TITLE
Add checks/statuses read permissions to Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,6 +24,8 @@ jobs:
       issues: read
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
+      checks: read
+      statuses: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -34,11 +36,14 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
+          github_token: ${{ github.token }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
+            checks: read
+            statuses: read
 
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'


### PR DESCRIPTION
Applies the workflow update from [shakacode/react_on_rails#2487](https://github.com/shakacode/react_on_rails/pull/2487):

- add `checks: read` and `statuses: read` to job permissions
- pass `github_token: ${{ github.token }}` to `anthropics/claude-code-action`
- add `checks: read` and `statuses: read` to `additional_permissions`

Admin merge requested to keep rollout fast across repos.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow permission changes; main risk is unintentionally broadening GitHub token read access to checks/statuses for the Claude job.
> 
> **Overview**
> Updates the `Claude Code` GitHub Actions workflow to **allow Claude to read CI check runs and commit statuses** by adding `checks: read` and `statuses: read` to both the job `permissions` and the action `additional_permissions`.
> 
> Also passes `github_token: ${{ github.token }}` into `anthropics/claude-code-action@v1` so the action can use the workflow token when querying GitHub APIs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e886ebe27574170d3e1cd804eb5d7128c4832f22. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->