### PR TITLE
Add July 2026 release, triage, and adoption roadmap

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,25 @@
+# Context
+
+Canonical vocabulary for this project. If a term here conflicts with usage in
+an issue, PR, or doc, this file wins; update it deliberately, not incidentally.
+
+## Naming (resolved 2026-07-04, see ADR-0001)
+
+| Term | Meaning |
+|---|---|
+| `cypress-on-rails` | The published gem name through the 1.x line. Canonical in Gemfiles today. |
+| `e2e_on_rails` | Reserved alias gem (thin wrapper depending on `cypress-on-rails`). Becomes the canonical gem name at 2.0, with `cypress-on-rails` becoming the compatibility shim. |
+| `CypressOnRails` | The Ruby module namespace through 1.x. Renames (to `E2eOnRails`, with a deprecation alias) only at 2.0. |
+| `cypress-playwright-on-rails` | The GitHub repository name. Not a gem name; do not use it in Gemfiles. |
+| Docs site | `testing.shakastack.com` (decision 2026-07-04). No dedicated domain unless/until the 2.0 rename ships. |
+
+## Core domain terms
+
+| Term | Meaning |
+|---|---|
+| install folder | The app-side directory (default `e2e/`, config `install_folder`) holding `e2e_helper.rb`, `app_commands/`, and framework config. Since v1.20.0, helper and commands live at its **root**, not inside `cypress/`. |
+| app command | A Ruby file in `app_commands/` executed in the Rails process when a test calls `cy.app(...)` / `app(...)`. The middleware's unit of remote execution. |
+| scenario | An app command under `app_commands/scenarios/` that seeds a named state, invoked via `cy.appScenario(...)`. |
+| middleware | `CypressOnRails::Middleware`, mounted outside production only, serving the `__e2e__` (legacy `__cypress__`) API prefix. Executes arbitrary Ruby by design — see README security model and issue #13. |
+| managed server | The Rails server started/stopped by the `cypress:*` / `playwright:*` rake tasks (since v1.19.0), with lifecycle hooks (`before_server_start`, …, `before_server_stop`). |
+| transactional server | `transactional_server` mode wrapping the run in a rolled-back DB transaction, reset via `/cypress_rails_reset_state` (cypress-rails-compatible endpoint). |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -9,7 +9,7 @@ an issue, PR, or doc, this file wins; update it deliberately, not incidentally.
 |---|---|
 | **E2E on Rails** | The public/brand name of the project (ADR-0002). Tagline: "The Rails test bridge for Cypress and Playwright." |
 | `cypress-on-rails` | The published gem name through the 1.x line. Canonical in Gemfiles until 2.0, then the compatibility shim. |
-| `e2e_on_rails` | Thin wrapper gem today (#226); the canonical gem from 2.0. 2.0 is scheduled right after the v1.22 line ships. |
+| `e2e_on_rails` | Thin wrapper gem, not yet published (#226 tracks it); the canonical gem from 2.0. 2.0 is scheduled right after the v1.22 line ships. |
 | `CypressOnRails` | The Ruby module namespace through 1.x. Renames to `E2eOnRails` (with a `CypressOnRails` deprecation alias) at 2.0. |
 | `cypress-playwright-on-rails` | Current GitHub repository name; renames to `shakacode/e2e-on-rails` immediately after v1.21.0 ships (GitHub redirects). Never a gem name. |
 | `e2eonrails.com` | Purchased 2026-07-04. Canonical docs + landing page at the apex (no `docs.` subdomain, no defensive variants). Supersedes the earlier testing.shakastack.com plan. |
@@ -18,7 +18,7 @@ an issue, PR, or doc, this file wins; update it deliberately, not incidentally.
 
 | Term | Meaning |
 |---|---|
-| install folder | The app-side directory (default `e2e/`, config `install_folder`) holding `e2e_helper.rb`, `app_commands/`, and framework config. Since v1.20.0, helper and commands live at its **root**, not inside `cypress/`. |
+| install folder | The app-side directory (config `install_folder`) holding `e2e_helper.rb`, `app_commands/`, and framework config. The install **generator** defaults it to `e2e/`; the gem's `Configuration#reset` defaults to `spec/e2e` for apps configured without the generator. Since v1.20.0, helper and commands live at its **root**, not inside `cypress/`. |
 | app command | A Ruby file in `app_commands/` executed in the Rails process when a test calls `cy.app(...)` / `app(...)`. The middleware's unit of remote execution. |
 | scenario | An app command under `app_commands/scenarios/` that seeds a named state, invoked via `cy.appScenario(...)`. |
 | middleware | `CypressOnRails::Middleware`, mounted outside production only, serving the `__e2e__` (legacy `__cypress__`) API prefix. Executes arbitrary Ruby by design — see README security model and issue #13. |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -3,15 +3,16 @@
 Canonical vocabulary for this project. If a term here conflicts with usage in
 an issue, PR, or doc, this file wins; update it deliberately, not incidentally.
 
-## Naming (resolved 2026-07-04, see ADR-0001)
+## Naming (resolved 2026-07-04, see ADR-0001 + ADR-0002)
 
 | Term | Meaning |
 |---|---|
-| `cypress-on-rails` | The published gem name through the 1.x line. Canonical in Gemfiles today. |
-| `e2e_on_rails` | Reserved alias gem (thin wrapper depending on `cypress-on-rails`). Becomes the canonical gem name at 2.0, with `cypress-on-rails` becoming the compatibility shim. |
-| `CypressOnRails` | The Ruby module namespace through 1.x. Renames (to `E2eOnRails`, with a deprecation alias) only at 2.0. |
-| `cypress-playwright-on-rails` | The GitHub repository name. Not a gem name; do not use it in Gemfiles. |
-| Docs site | `testing.shakastack.com` (decision 2026-07-04). No dedicated domain unless/until the 2.0 rename ships. |
+| **E2E on Rails** | The public/brand name of the project (ADR-0002). Tagline: "The Rails test bridge for Cypress and Playwright." |
+| `cypress-on-rails` | The published gem name through the 1.x line. Canonical in Gemfiles until 2.0, then the compatibility shim. |
+| `e2e_on_rails` | Thin wrapper gem today (#226); the canonical gem from 2.0. 2.0 is scheduled right after the v1.22 line ships. |
+| `CypressOnRails` | The Ruby module namespace through 1.x. Renames to `E2eOnRails` (with a `CypressOnRails` deprecation alias) at 2.0. |
+| `cypress-playwright-on-rails` | Current GitHub repository name; renames to `shakacode/e2e-on-rails` immediately after v1.21.0 ships (GitHub redirects). Never a gem name. |
+| `e2eonrails.com` | Purchased 2026-07-04. Canonical docs + landing page at the apex (no `docs.` subdomain, no defensive variants). Supersedes the earlier testing.shakastack.com plan. |
 
 ## Core domain terms
 

--- a/docs/adr/0001-reserve-e2e_on_rails-rename-at-2.0.md
+++ b/docs/adr/0001-reserve-e2e_on_rails-rename-at-2.0.md
@@ -1,0 +1,46 @@
+# ADR-0001: Reserve `e2e_on_rails` as an alias gem now; full rename at 2.0
+
+Date: 2026-07-04
+Status: Accepted (@justin808)
+
+## Context
+
+The gem is named `cypress-on-rails` but has supported Playwright since v1.15.0,
+and its internal vocabulary already moved to framework-neutral "e2e" (`__e2e__`
+API prefix, `e2e/` install folder, `e2e_helper.rb`). Playwright users cannot
+find the gem by name; the name also misstates the product while we court
+users of the dormant cypress-rails gem.
+
+Constraints discovered during evaluation (2026-07-04):
+
+- `playwright-on-rails` is already taken on RubyGems by an unrelated gem —
+  evidence that candidate names get claimed.
+- `e2e_on_rails`, `e2e-on-rails`, and `rails-e2e` were all unclaimed.
+- `cypress-on-rails` has 6.4M lifetime downloads of brand equity, and a rename
+  mid-1.x would churn Gemfiles exactly while we are pitching stability to
+  cypress-rails migrants (issues #220/#224).
+
+## Decision
+
+1. Publish **`e2e_on_rails`** now as a thin wrapper gem: it pins
+   `cypress-on-rails` to the current minor and its require file loads
+   `cypress_on_rails`. Version mirrors the parent gem. This secures the name
+   and gives "e2e rails" searchers a working install path immediately.
+2. Underscore spelling (`e2e_on_rails`) per RubyGems convention for standalone
+   gems, matching the future `E2eOnRails` module; chosen over family
+   consistency with the dash in `cypress-on-rails`.
+3. At **2.0** (no date set): `e2e_on_rails` becomes the canonical gem;
+   `cypress-on-rails` becomes the compatibility shim; module renames to
+   `E2eOnRails` with a `CypressOnRails` deprecation alias.
+4. No docs domain purchase until the 2.0 flip; docs live at
+   testing.shakastack.com (see roadmap S2).
+
+## Consequences
+
+- Two gems to bump per release (wrapper bump is scriptable in the release task).
+- Dual branding in docs ("cypress-on-rails, becoming e2e_on_rails") until 2.0.
+- The 2.0 module rename is the expensive, breaking part and stays deferred;
+  nothing in 1.x may depend on the new name existing.
+- Alternatives rejected: full rename now (Gemfile churn during the migration
+  campaign); status quo (leaves the name claimable by others, as happened
+  with `playwright-on-rails`).

--- a/docs/adr/0001-reserve-e2e_on_rails-rename-at-2.0.md
+++ b/docs/adr/0001-reserve-e2e_on_rails-rename-at-2.0.md
@@ -1,7 +1,9 @@
 # ADR-0001: Reserve `e2e_on_rails` as an alias gem now; full rename at 2.0
 
 Date: 2026-07-04
-Status: Accepted (@justin808)
+Status: Accepted (@justin808); amended same day by ADR-0002 (public brand
+"E2E on Rails", e2eonrails.com purchased, repo rename after v1.21.0, 2.0
+scheduled after v1.22). Wrapper-gem mechanics below remain in force.
 
 ## Context
 

--- a/docs/adr/0001-reserve-e2e_on_rails-rename-at-2.0.md
+++ b/docs/adr/0001-reserve-e2e_on_rails-rename-at-2.0.md
@@ -24,7 +24,9 @@ Constraints discovered during evaluation (2026-07-04):
 
 ## Decision
 
-1. Publish **`e2e_on_rails`** now as a thin wrapper gem: it pins
+1. Publish **`e2e_on_rails`** now as a thin wrapper gem (availability was
+   checked 2026-07-04; re-verify on rubygems.org immediately before the first
+   publish — see #226): it pins
    `cypress-on-rails` to the current minor and its require file loads
    `cypress_on_rails`. Version mirrors the parent gem. This secures the name
    and gives "e2e rails" searchers a working install path immediately.

--- a/docs/adr/0002-public-rebrand-e2e-on-rails.md
+++ b/docs/adr/0002-public-rebrand-e2e-on-rails.md
@@ -40,6 +40,21 @@ were resolved by the maintainer on 2026-07-04:
 5. **No gem split** (reaffirms closing #24); if a split ever happens it uses
    the `e2e_on_rails-*` prefix per the naming doc.
 
+## Stats preservation (explicit guarantee, added 2026-07-04)
+
+Nothing in this rebrand discards accumulated social proof or history:
+
+- **GitHub:** the rename (#228) is in-place — stars, forks, watchers, issues,
+  PRs, and traffic history all carry over, and old URLs/git remotes redirect
+  permanently. Precedent: this repo already renamed once
+  (cypress-on-rails → cypress-playwright-on-rails) and lost nothing.
+  Do NOT create a fresh repo and archive the old one; that WOULD lose stats.
+- **RubyGems:** `cypress-on-rails` is never yanked. It remains the real gem
+  through 1.x and the published shim from 2.0 onward, so its ~6.4M download
+  history stays visible and keeps growing (shim installs also pull
+  `e2e_on_rails`, so the new gem accrues its own count on top). Marketing and
+  README cite the lineage: "6.4M+ downloads as cypress-on-rails".
+
 ## Consequences
 
 - Docs-site work (#221/#222 outputs, migration guide #220) publishes to

--- a/docs/adr/0002-public-rebrand-e2e-on-rails.md
+++ b/docs/adr/0002-public-rebrand-e2e-on-rails.md
@@ -44,9 +44,9 @@ were resolved by the maintainer on 2026-07-04:
 
 Nothing in this rebrand discards accumulated social proof or history:
 
-- **GitHub:** the rename (#228) is in-place — stars, forks, watchers, issues,
-  PRs, and traffic history all carry over, and old URLs/git remotes redirect
-  permanently. Precedent: this repo already renamed once
+- **GitHub:** the rename (#228, pending — gated on v1.21.0 shipping) must be
+  an in-place GitHub rename — stars, forks, watchers, issues, PRs, and traffic
+  history all carry over, and old URLs/git remotes redirect permanently. Precedent: this repo already renamed once
   (cypress-on-rails → cypress-playwright-on-rails) and lost nothing.
   Do NOT create a fresh repo and archive the old one; that WOULD lose stats.
 - **RubyGems:** `cypress-on-rails` is never yanked. It remains the real gem

--- a/docs/adr/0002-public-rebrand-e2e-on-rails.md
+++ b/docs/adr/0002-public-rebrand-e2e-on-rails.md
@@ -1,0 +1,54 @@
+# ADR-0002: Public rebrand to "E2E on Rails"; gem flip is 2.0, scheduled after v1.22
+
+Date: 2026-07-04
+Status: Accepted (@justin808)
+Amends: ADR-0001 (alias mechanics unchanged; brand scope and timing extended)
+
+## Context
+
+ADR-0001 reserved `e2e_on_rails` as a wrapper gem and deferred all renaming to
+an unscheduled 2.0, with docs at testing.shakastack.com. A fuller naming
+evaluation (see `docs/roadmap/2026-07-e2e-on-rails-naming-decision.md`,
+adopted 2026-07-04) chose a complete public brand — **E2E on Rails** — and
+**e2eonrails.com** was purchased the same day. Two ambiguities in that document
+were resolved by the maintainer on 2026-07-04:
+
+1. Its Phase 2 ("new preferred gem") did not date the gem flip.
+2. Its Phase 1 (repo rename) did not sequence against the pending v1.21.0 release.
+
+## Decision
+
+1. **Brand now:** public name **E2E on Rails**; tagline
+   *"The Rails test bridge for Cypress and Playwright."*
+2. **Domain:** `e2eonrails.com` (purchased) is the canonical docs + landing
+   page at the apex — no `docs.` subdomain, no defensive domain variants.
+   Supersedes the testing.shakastack.com plan from ADR-0001/roadmap S2.
+   Renewal rule per the naming doc: keep after year one only if it carries
+   real traffic/links; otherwise fold docs back under ShakaCode.
+3. **Repo rename** to `shakacode/e2e-on-rails` **immediately after v1.21.0
+   ships** (GitHub redirects old URLs), together with the README hero from the
+   naming doc ("Formerly `cypress-on-rails`") and a sweep of gemspec/badge/
+   workflow/docs URLs. The v1.21.0 release itself runs under the current name.
+4. **Gem flip is 2.0, and 2.0 is scheduled**: right after the v1.22 line
+   (hardening #185/#186/#13 + migration guide #220) lands — target ~2–3
+   months out. At 2.0: code moves to `e2e_on_rails`, `cypress-on-rails`
+   becomes the compatibility shim, module renames to `E2eOnRails` with a
+   `CypressOnRails` deprecation alias. Until then `e2e_on_rails` stays the
+   thin wrapper from ADR-0001 (#226) and install instructions keep saying
+   `gem 'cypress-on-rails'`, so cypress-rails migrants experience exactly one
+   rename event.
+5. **No gem split** (reaffirms closing #24); if a split ever happens it uses
+   the `e2e_on_rails-*` prefix per the naming doc.
+
+## Consequences
+
+- Docs-site work (#221/#222 outputs, migration guide #220) publishes to
+  e2eonrails.com with the IA from the naming doc
+  (`/getting-started`, `/cypress`, `/playwright`, `/factory-bot`, `/fixtures`,
+  `/scenarios`, `/app-commands`, `/migration/from-cypress-on-rails`).
+- The v1.22 outreach (#224) leads with the E2E on Rails brand while still
+  instructing `gem 'cypress-on-rails'` — the guide must say the 2.0 name
+  change is coming and that the shim will keep old Gemfiles working.
+- A 2.0 flip checklist issue tracks the inversion; the wrapper gem (#226)
+  ships with e2eonrails.com metadata so its RubyGems page is on-brand from
+  day one.

--- a/docs/roadmap/2026-07-e2e-on-rails-naming-decision.md
+++ b/docs/roadmap/2026-07-e2e-on-rails-naming-decision.md
@@ -1,0 +1,321 @@
+# Naming Decision: E2E on Rails
+
+## Status
+
+Decision: rename the project to **E2E on Rails** and use **e2eonrails.com** as the canonical docs domain.
+
+## Decision summary
+
+| Item | Decision |
+| --- | --- |
+| Public name | **E2E on Rails** |
+| GitHub repository | `shakacode/e2e-on-rails` |
+| New v2 gem | `e2e_on_rails` |
+| Legacy gem | Keep `cypress-on-rails` as the compatibility/deprecation path |
+| Docs domain | `e2eonrails.com` |
+| Defensive domains | Do **not** buy variants unless the project later becomes a larger commercial product |
+| Tagline | The Rails test bridge for Cypress and Playwright. |
+
+## One-sentence positioning
+
+**E2E on Rails lets Cypress and Playwright tests use your real Rails test setup: FactoryBot, fixtures, database cleanup, scenarios, VCR, and custom app commands.**
+
+## Domain decision
+
+Use one canonical domain:
+
+```text
+e2eonrails.com
+```
+
+Do **not** defensively register variants right now:
+
+```text
+e2erails.com
+railse2e.com
+e2e-on-rails.com
+e2eonrails.dev
+e2eonrails.org
+rails-e2e.com
+```
+
+Reasoning:
+
+- The strongest assets for an OSS gem are the GitHub repo, gem name, README, RubyGems page, and ShakaCode authority.
+- The domain matters, but it does not justify domain clutter.
+- `e2eonrails.com` matches the brand phrase **E2E on Rails** exactly.
+- `e2erails.com` is shorter, but it reads like a clipped category phrase, “E2E Rails,” not the project name.
+- `railse2e.com` is useful as a keyword phrase, but it reverses the brand and feels more generic.
+- The word **on** is valuable because it connects this project to the naming lineage of **React on Rails** and **Cypress on Rails**.
+
+## Domain usage
+
+Make the apex domain the docs and landing page:
+
+```text
+e2eonrails.com
+```
+
+Do not start with a separate docs subdomain:
+
+```text
+docs.e2eonrails.com
+```
+
+For an OSS gem, the docs homepage can also be the marketing homepage. A separate marketing site can be added later only if the project becomes more commercial.
+
+Recommended docs structure:
+
+```text
+/
+  What is E2E on Rails?
+/getting-started
+/cypress
+/playwright
+/factory-bot
+/fixtures
+/scenarios
+/app-commands
+/migration/from-cypress-on-rails
+```
+
+Renewal rule: keep the domain after the first year only if it has real value, such as docs, README links, RubyGems links, backlinks, search traffic, or product value. Otherwise, fold the docs back under ShakaCode and let the domain expire.
+
+## Why this name
+
+The current repo name, `cypress-playwright-on-rails`, is accurate but too long and tool-list-like. It also risks aging poorly if another browser automation tool becomes important later.
+
+The old name, `cypress-on-rails`, made sense when the project was Cypress-specific. Today, the project supports both Cypress and Playwright, so leading with “Cypress” under-sells the broader purpose.
+
+**E2E on Rails** is stronger because it is:
+
+- Short and memorable.
+- Searchable for “e2e tests rails”.
+- Broad enough to cover Cypress, Playwright, and future browser runners.
+- Clear to Rails developers that the project belongs in the Rails testing ecosystem.
+- Clear to JavaScript/browser-test developers that this is about end-to-end testing, not just Rails system tests.
+- Aligned with the existing ShakaCode naming pattern around Rails integration projects.
+
+## Recommended tagline options
+
+Primary tagline:
+
+> The Rails test bridge for Cypress and Playwright.
+
+Alternative taglines:
+
+> Use Cypress or Playwright with your real Rails test setup.
+
+> Rails-native test data, factories, fixtures, and app commands for modern browser tests.
+
+> Bring Rails test power to Cypress and Playwright.
+
+## Ecosystem notes
+
+The name should avoid being locked to either Cypress or Playwright because existing gems already occupy those mental categories:
+
+- `cypress-rails` is Cypress-specific.
+- `playwright-on-rails` is Playwright-specific.
+- `browser` is already a major Ruby gem name associated with browser detection, so names like `browser_on_rails` may be ambiguous.
+- A plain `e2e` name is too broad and may conflict with other testing projects, so the full phrase **E2E on Rails** is stronger.
+
+## Search positioning
+
+The name should support these search intents:
+
+- e2e tests rails
+- browser tests rails
+- playwright rails
+- cypress rails
+- rails test data cypress
+- rails test data playwright
+- factorybot cypress rails
+- factorybot playwright rails
+
+**E2E on Rails** gives the project a clean umbrella brand while the documentation can still target Cypress and Playwright keyword searches directly.
+
+## Notes from issue #11: gem rename
+
+Issue #11 proposed a rename toward the clearer `cypress_on_rails` / `CypressOnRails` naming style.
+
+That direction was reasonable in 2019 because the project was still Cypress-centered. In the current state, however, adopting a Cypress-only name would not reflect Playwright support.
+
+Decision from that issue, updated for today:
+
+- Do not use `cypress_on_rails` as the new primary name.
+- Keep `cypress-on-rails` as a legacy compatibility gem.
+- Introduce `e2e_on_rails` as the forward-looking umbrella gem.
+
+## Notes from issue #24: gem split
+
+Issue #24 proposed splitting the gem into focused components, such as support for factories, fixtures, scenarios, and app-command execution.
+
+That idea still makes sense architecturally, but the naming should now use the broader E2E brand instead of a Cypress-specific prefix.
+
+Possible future split:
+
+```ruby
+gem "e2e_on_rails"                 # umbrella
+gem "e2e_on_rails-cypress"         # Cypress adapter
+gem "e2e_on_rails-playwright"      # Playwright adapter
+gem "e2e_on_rails-factory_bot"     # FactoryBot support
+gem "e2e_on_rails-fixtures"        # ActiveRecord fixture support
+gem "e2e_on_rails-scenarios"       # scenario/app command support
+```
+
+Recommendation: start with one umbrella gem first. Splitting too early creates more maintenance, more documentation, and more decisions for adopters. Split later only if separate packages create a clear maintenance or adoption benefit.
+
+## Migration plan
+
+### Phase 1: Rename the public project
+
+Rename the repo from:
+
+```text
+shakacode/cypress-playwright-on-rails
+```
+
+to:
+
+```text
+shakacode/e2e-on-rails
+```
+
+Update the README title:
+
+```md
+# E2E on Rails
+
+The Rails test bridge for Cypress and Playwright.
+
+Formerly cypress-on-rails.
+
+Use Cypress or Playwright with your Rails test setup: FactoryBot, fixtures, database cleanup, scenarios, VCR, and custom app commands.
+```
+
+### Phase 2: Introduce the new gem
+
+Add a new preferred gem:
+
+```ruby
+gem "e2e_on_rails"
+```
+
+Keep the existing gem working:
+
+```ruby
+gem "cypress-on-rails"
+```
+
+The legacy gem can either depend on `e2e_on_rails` or act as a compatibility wrapper.
+
+### Phase 3: Launch the docs domain
+
+Use:
+
+```text
+e2eonrails.com
+```
+
+as the canonical docs and landing page.
+
+Link to this domain from:
+
+- GitHub README.
+- RubyGems page.
+- ShakaCode site.
+- Any migration notices in the legacy gem docs.
+
+Do not buy defensive variants unless the project later has enough commercial gravity to justify the extra renewal overhead.
+
+### Phase 4: Update documentation and examples
+
+Update docs to lead with the umbrella concept:
+
+```text
+E2E on Rails supports Cypress and Playwright.
+```
+
+Then create runner-specific sections:
+
+```text
+Using E2E on Rails with Cypress
+Using E2E on Rails with Playwright
+```
+
+This keeps the project name stable while preserving search visibility for both tools.
+
+## Recommended README hero section
+
+```md
+# E2E on Rails
+
+The Rails test bridge for Cypress and Playwright.
+
+E2E on Rails lets modern browser tests use your real Rails test setup:
+FactoryBot, fixtures, database cleanup, scenarios, VCR, and custom app commands.
+
+Docs: https://e2eonrails.com
+
+Formerly `cypress-on-rails`.
+```
+
+## Recommended docs homepage hero section
+
+```md
+# E2E on Rails
+
+Cypress and Playwright tests with real Rails data, factories, fixtures, and app commands.
+
+E2E on Rails is the Rails test bridge for modern browser automation. It lets your E2E tests reset the database, create records with FactoryBot, load fixtures, run scenarios, and call custom Rails-side commands.
+
+[Get started](/getting-started)
+```
+
+## Names considered
+
+| Rank | Name | Repo / gem shape | Assessment |
+| ---: | --- | --- | --- |
+| 1 | **E2E on Rails** | `e2e-on-rails` / `e2e_on_rails` | Best balance of catchy, searchable, and future-proof. |
+| 2 | Rails E2E Bridge | `rails-e2e-bridge` / `rails_e2e_bridge` | Technically precise, but less elegant as a brand. |
+| 3 | Rails Browser Kit | `rails-browser-kit` / `rails_browser_kit` | Good for “browser tests Rails,” but less clearly Cypress/Playwright/E2E. |
+| 4 | Rails Test Bridge | `rails-test-bridge` / `rails_test_bridge` | Accurate architecture, but too broad for search. |
+| 5 | Browser on Rails | `browser-on-rails` / `browser_on_rails` | Catchy, but “browser” is ambiguous in the Ruby ecosystem. |
+| 6 | Rails E2E Kit | `rails-e2e-kit` / `rails_e2e_kit` | Clear, but less memorable than “E2E on Rails.” |
+
+## Domain names considered
+
+| Rank | Domain | Assessment |
+| ---: | --- | --- |
+| 1 | `e2eonrails.com` | Best match to the brand phrase **E2E on Rails**. Use this. |
+| 2 | `e2erails.com` | Shorter, but sounds clipped and less connected to the “on Rails” brand pattern. |
+| 3 | `railse2e.com` | Good keyword phrase, but weaker as a brand and reversed from the project name. |
+| 4 | `e2e-on-rails.com` | Exact phrase with hyphens, but not worth another renewal. |
+| 5 | `.dev` / `.org` variants | Not worth buying unless the project becomes a larger commercial product. |
+
+## Names to avoid
+
+Avoid `cypress-playwright-on-rails` as the long-term name. It is descriptive but too long and too tied to the current runner list.
+
+Avoid `cypress_on_rails` as the new headline name. It solves the old rename problem but not the current multi-runner positioning problem.
+
+Avoid `rails-system-tests-*` unless the goal is to position the project directly inside Rails’ native System Test / Capybara world. It is Rails-accurate but less compelling for Cypress and Playwright users.
+
+Avoid buying multiple domain variants for the current OSS stage. The project does not need defensive domain clutter.
+
+## Final recommendation
+
+Rename the project to **E2E on Rails**.
+
+Use:
+
+```text
+Project:  E2E on Rails
+Repo:     shakacode/e2e-on-rails
+Gem:      e2e_on_rails
+Legacy:   cypress-on-rails
+Docs:     e2eonrails.com
+Tagline:  The Rails test bridge for Cypress and Playwright.
+```
+
+This name is short, searchable, runner-neutral, clear about the project’s Rails identity, and aligned with the `on Rails` naming pattern. The domain decision is intentionally simple: buy and use **e2eonrails.com**, and skip the defensive variants.

--- a/docs/roadmap/2026-07-release-and-adoption-plan.md
+++ b/docs/roadmap/2026-07-release-and-adoption-plan.md
@@ -25,11 +25,12 @@ Owner: @justin808
 1. v1.21.0 scope and R1/R2 merge order — **approved, executed**.
 2. Seven close-candidates — **approved, closed**.
 3. #24 (gem split) and #11 (rename) — **closed**.
-4. Docs site (S2) — **testing.shakastack.com for now**; no domain purchase
-   until the 2.0 rename ships. Gem naming — **RESOLVED 2026-07-04
-   (ADR-0001)**: publish `e2e_on_rails` now as a thin alias/wrapper gem;
-   full rename (canonical gem `e2e_on_rails`, module `E2eOnRails`,
-   `cypress-on-rails` as shim) happens at 2.0. Supersedes §S4's option list.
+4. Naming & docs site — **RESOLVED 2026-07-04, twice refined (ADR-0001 →
+   ADR-0002)**: public brand is **E2E on Rails**; `e2eonrails.com` purchased
+   and canonical (supersedes testing.shakastack.com); repo renames to
+   `shakacode/e2e-on-rails` right after v1.21.0 ships; `e2e_on_rails` wrapper
+   now (#226); the gem flip is 2.0, scheduled right after the v1.22 line.
+   Full rationale: `docs/roadmap/2026-07-e2e-on-rails-naming-decision.md`.
 5. Outreach (M3) — approved in principle; post only after v1.21.0 +
    hardening (#185) + migration guide (#220) ship. Draft lives in #224.
 6. #191/#193 (release task, RuboCop) — **after** v1.21.0.
@@ -245,18 +246,25 @@ spec headlessly, and get a deterministic pass/fail without clicking around.
   and extend "Prove" to two legs: *prove it's fast* (ShakaPerf) + *prove it
   works* (this gem). Owner: whoever edits shakastack.com (site repo UNKNOWN —
   locate first).
-- **S2 — docs site (DECIDED 2026-07-04):** publish to
-  **testing.shakastack.com**; no dedicated domain unless/until the 2.0 rename
-  ships (see ADR-0001). Implementation task: stand up the docs site there
-  once #221 (README/docs split) lands, and publish `llms.txt` from #222.
+- **S2 — docs site (DECIDED 2026-07-04, ADR-0002):** publish to
+  **e2eonrails.com** (purchased; apex is docs + landing, no `docs.`
+  subdomain, no defensive domain variants). IA from the naming doc:
+  `/getting-started`, `/cypress`, `/playwright`, `/factory-bot`, `/fixtures`,
+  `/scenarios`, `/app-commands`, `/migration/from-cypress-on-rails`.
+  Stand it up once #221 (README/docs split) lands; publish `llms.txt` (#222)
+  there.
 - **S3 — cross-promotion:** react_on_rails already uses this gem for its E2E
   suite — write that up (blog or docs page "How React on Rails tests itself
   with Playwright"), link from react_on_rails docs and AGENTS_USER_GUIDE.
-- **S4 — naming (DECIDED 2026-07-04, ADR-0001; #11/#24 closed):** publish
-  `e2e_on_rails` now as a thin alias gem (issue #226); full rename — canonical
-  gem `e2e_on_rails`, module `E2eOnRails`, `cypress-on-rails` as shim — at
-  2.0. See `docs/adr/0001-reserve-e2e_on_rails-rename-at-2.0.md` and
-  `CONTEXT.md` for the canonical vocabulary.
+- **S4 — naming (DECIDED 2026-07-04, ADR-0001 + ADR-0002; #11/#24 closed):**
+  public brand **E2E on Rails** ("The Rails test bridge for Cypress and
+  Playwright"). Sequence: v1.21.0 releases under the current names → repo
+  renames to `shakacode/e2e-on-rails` + README hero rebrand → v1.22 campaign
+  runs under the new brand with `gem 'cypress-on-rails'` still the install →
+  **2.0 = the gem flip** (`e2e_on_rails` canonical, `cypress-on-rails` shim,
+  module `E2eOnRails`), scheduled right after v1.22. See
+  `docs/roadmap/2026-07-e2e-on-rails-naming-decision.md`, ADR-0002, and
+  `CONTEXT.md`.
 
 ---
 
@@ -267,15 +275,16 @@ Decisions section at the top of this document). Still genuinely open:
 
 1. Final sign-off on the M3 outreach comment text before posting (draft in
    issue #224; gated on v1.21.0 + #185 + #220 shipping).
-2. Timing of the 2.0 rename flip (deliberately unscheduled — ADR-0001).
 
 ## 6. Suggested agent execution order
 
 ```text
-R4(human release)                     # only v1.21.0 step left
-#226 alias gem → H1 → H2 → H3 → M1 → M2 → M4   # hardening before marketing
-A1 → A2 → A3 → A4 → A5                # agent-native layer (issues #222/#223/#78)
-S1–S3 in parallel (site/marketing, human-led)
+R4(human release)                        # only v1.21.0 step left
+repo rename + README hero (post-v1.21.0, ADR-0002)
+#226 alias gem → H1 → H2 → H3 → M1 → M2 → M4   # v1.22: hardening before marketing
+2.0 flip (right after v1.22): e2e_on_rails canonical, cypress-on-rails shim
+A1 → A2 → A3 → A4 → A5                   # agent-native layer (issues #222/#223/#78)
+S1–S3 in parallel (site/marketing, human-led); docs site = e2eonrails.com
 ```
 
 Every task above states its issue/PR, files, and acceptance criteria; tasks

--- a/docs/roadmap/2026-07-release-and-adoption-plan.md
+++ b/docs/roadmap/2026-07-release-and-adoption-plan.md
@@ -34,6 +34,7 @@ Owner: @justin808
 5. Outreach (M3) — approved in principle; post only after v1.21.0 +
    hardening (#185) + migration guide (#220) ship. Draft lives in #224.
 6. #191/#193 (release task, RuboCop) — **after** v1.21.0.
+
 Audience: maintainers **and coding agents**. Every task below is written to be
 implementable by an agent without additional context. Facts were verified on
 2026-07-03; re-verify anything marked VERIFY before acting on it.
@@ -187,11 +188,18 @@ cypress-rails users.
   app (this is the exact failure mode that killed cypress-rails — see
   testdouble/cypress-rails#164).
 - **H2 (issue #186) — PR #180 review follow-ups.** Small; do with H1.
-- **H3 (issue #13) — security hardening.** Add an opt-in shared-secret token
-  check to the middleware (`c.middleware_token = ENV[...]`; requests without
-  the header 403) + README warning rewrite. Do NOT enable middleware outside
-  dev/test by default (already the case — `use_middleware = !Rails.env.production?`;
-  VERIFY current default in `lib/cypress_on_rails/configuration.rb`).
+- **H3 (issue #13) — security hardening.** ⚠️ Two verified facts constrain the
+  design (2026-07-05 review): (1) the gem's own default is **unsafe** —
+  `Configuration#reset` sets `use_middleware = true` unconditionally; the
+  `!Rails.env.production?` guard exists only in the *generated* initializer
+  template, so apps configured by hand get the middleware in every
+  environment. Fixing that library default is part of H3. (2) An auth hook
+  **already exists**: `before_request` runs at the top of
+  `Middleware#handle_command`, the generated initializer shows a 403 example,
+  and README §"Authenticate CypressOnRails" documents secret-token auth with
+  it. H3 must first evaluate hardening/documenting `before_request` (or
+  building `middleware_token` as thin sugar over it) rather than shipping a
+  second, overlapping auth mechanism. Full spec in issue #13.
 - **M1 — `docs/MIGRATE_FROM_CYPRESS_RAILS.md`.** The centerpiece. Structure:
   1. Why (dormant since 2024, Rails 7.2+ broken, no Playwright — with links);
   2. Concept map table (their env vars/hooks/reset endpoint → ours; most map 1:1 since v1.19.0);

--- a/docs/roadmap/2026-07-release-and-adoption-plan.md
+++ b/docs/roadmap/2026-07-release-and-adoption-plan.md
@@ -1,0 +1,260 @@
+# Release & Adoption Plan — July 2026
+
+Status: PROPOSED (triage applied to GitHub 2026-07-03; everything else awaits maintainer sign-off)
+Owner: @justin808
+Audience: maintainers **and coding agents**. Every task below is written to be
+implementable by an agent without additional context. Facts were verified on
+2026-07-03; re-verify anything marked VERIFY before acting on it.
+
+---
+
+## 1. Current state (verified 2026-07-03)
+
+| Fact | Value |
+|---|---|
+| Gem name | `cypress-on-rails` (repo renamed to `cypress-playwright-on-rails`) |
+| Latest RubyGems release | 1.20.0 (2025-10-21) |
+| Lifetime downloads | 6,412,456 |
+| GitHub stars / forks | 453 / 61 |
+| Latest **GitHub Release** | v1.15.0 (2023-07-05) — 5 versions behind RubyGems |
+| Unreleased commits on master | 7 (notably Rails 8.1 compat fix #207, generator whitespace fix #205) |
+| Open issues / PRs | 21 / 6 (all triage-labeled as of 2026-07-03) |
+
+### The competitive moment (why now)
+
+[testdouble/cypress-rails](https://github.com/testdouble/cypress-rails) is
+**effectively dormant**:
+
+- Last commit to main: 2024-09-06 (v0.7.1). Last maintainer activity of any kind: Nov 2024.
+- **Broken on Rails 7.2+** ([testdouble/cypress-rails#164](https://github.com/testdouble/cypress-rails/issues/164), 31 comments):
+  `ConnectionPool#lock_thread=` was removed in Rails 7.2. The only fix is
+  0.8.0.rc1, which was never finalized and causes state-reset failures / Puma
+  hangs for some users. Users are on personal forks or stuck.
+- 1.19M lifetime downloads (0.8.0.rc1 alone has 189k — an active, stranded CI user base).
+- No Playwright support, none planned. Justin Searls publicly moved to
+  Playwright for Rails browser testing (justin.searls.co, June 2024).
+
+cypress-on-rails **v1.19.0 already shipped the parity features** those users
+would need: `cypress:open`/`cypress:run` rake tasks, automatic server
+start/stop, `before_server_start`/`after_server_start`/`after_transaction_start`/`after_state_reset`/`before_server_stop`
+hooks, transactional test mode, the `/cypress_rails_reset_state` endpoint, and
+`CYPRESS_RAILS_HOST`/`CYPRESS_RAILS_PORT` env vars. What's missing is
+**hardening (issue #185), a migration guide, and marketing**.
+
+⚠️ **Strategic caveat:** cypress-rails died from a fragile transactional-server
+implementation under multi-threaded Puma. Our equivalent (merged in v1.19.0 via
+PR #179) has known robustness gaps tracked in **#185** and **#186**. Harden
+before marketing the migration path — attracting refugees onto a launcher that
+hangs would repeat the failure we're recruiting from.
+
+### ShakaStack fit (from shakastack.com research)
+
+- shakastack.com pitches "Ship modern React in Rails — fast, and prove it"
+  (Build → Deploy → Prove) and claims "the most agent-capable stack".
+  **The Prove phase currently only covers performance (ShakaPerf). E2E
+  correctness — this gem — is absent from shakastack.com and shakacode.com.**
+- react_on_rails already dogfoods this gem (its dummy-app E2E suite runs
+  Playwright *via cypress-on-rails*: `react_on_rails/spec/dummy/e2e/README.md`) — an
+  untold story.
+- Ecosystem conventions this repo doesn't yet follow: `AGENTS.md`
+  (contributor agents) + `AGENTS_USER_GUIDE.md` (users' agents) + `llms.txt`
+  (react_on_rails has all three), a `doctor` diagnostic task
+  (react_on_rails/shakapacker have one), a brief top-level README with docs
+  links (ours is 821 lines with the consulting block above the fold).
+
+---
+
+## 2. Triage results (labels applied 2026-07-03)
+
+New labels created: `documentation`, `security`, `needs-info`,
+`close-candidate`, `needs-rebase`, `needs-decision`, `priority: high`,
+`priority: medium`, `priority: low`, `agent-ready`, `cypress-rails-parity`,
+`ci-infra`.
+
+### PRs — recommended actions
+
+| PR | State | Action |
+|---|---|---|
+| [#210](https://github.com/shakacode/cypress-playwright-on-rails/pull/210) Don't override RAILS_ENV | Approved, CI green, mergeable | **Merge now.** Ships in v1.21.0 |
+| [#168](https://github.com/shakacode/cypress-playwright-on-rails/pull/168) Playwright `response.json()` fix | Approved but conflicting, +6/−3 | **Rebase, re-run CI, merge.** Ships in v1.21.0 (task R3) |
+| [#213](https://github.com/shakacode/cypress-playwright-on-rails/pull/213) Claude workflow | Conflicting; superseded by merged #211/#212/#214/#215 | **Close** as superseded |
+| [#193](https://github.com/shakacode/cypress-playwright-on-rails/pull/193) RuboCop | Changes requested, large | Keep; land after v1.21.0 to avoid churn (issue #197 tracks follow-ups) |
+| [#191](https://github.com/shakacode/cypress-playwright-on-rails/pull/191) Release task conflict | Conflicting, CI red, changes requested | Rebase or close/redo small; only touch alongside the release (task R6) |
+| [#173](https://github.com/shakacode/cypress-playwright-on-rails/pull/173) README: run server in test env | Conflicting; overlaps #210 and #157 | Decide docs stance on test-env (task M4), then rebase or close |
+
+### Issues — close candidates (resolved by shipped releases or stale)
+
+| Issue | Why closable | Close message should point to |
+|---|---|---|
+| #152 Auto-start rails server | Shipped in v1.19.0 (rake tasks + managed server) | CHANGELOG 1.19.0, `docs/` |
+| #153 Initialization hooks | Shipped in v1.19.0 (all 5 hooks it asked for) | CHANGELOG 1.19.0 |
+| #112 Integration tests Rails 6/7 | CI now covers Rails 6.1–8.x example apps; Rails 4/5 dropped in 1.18.0 | `.github/workflows/ruby.yml` |
+| #92 Stub outgoing requests | VCR middleware shipped in 1.18.0 covers this | `docs/VCR_GUIDE.md` |
+| #183 v1.19.0 release discussion | Release shipped 2025-10-01 | — |
+| #146 Webpack compilation error | Stale (2023), Cypress-side config, no repro | — |
+| PR #213 | Superseded (see above) | merged #211–#215 |
+
+**Agent instruction:** when closing, post a comment naming the release that
+resolved it and the doc to read; invite reopening if the shipped feature
+doesn't cover the reporter's case. Do not close silently.
+
+### Issues — keep open, prioritized
+
+| Priority | Issue | Notes |
+|---|---|---|
+| high | #185 server/state-reset hardening | Prerequisite for migration campaign (task H1) |
+| high | #13 RCE mitigation / middleware security | Long-standing adoption blocker; see task H3 |
+| medium | #186 follow-ups from PR #180 review | Small, `agent-ready` |
+| medium | #114 transactional fixtures | Partially addressed by v1.19 transactional mode; remaining: document + benchmark vs database_cleaner |
+| medium | #157 test-env reloading | Docs task M4; related to merged #210 |
+| medium | #78 TypeScript typings | `agent-ready`, task A4 |
+| medium | #80 Devise login helper, #81 ActionMailer email viewing | Good v1.22+ features, `agent-ready` |
+| low | #113 split experimental options, #197 RuboCop staging, #209 Lefthook | Housekeeping |
+| needs-info | #175 VCR route 404, #155 MySQL error | Ask for repro; auto-close in 30 days if silent |
+| needs-decision | #24 gem split (2019), #11 gem rename (2019) | Maintainer decision; recommend closing both as "won't do — stability is the brand" |
+
+---
+
+## 3. Release plan
+
+### v1.21.0 — "current & compatible" (target: within 2 weeks)
+
+Goal: flush 9 months of unreleased fixes, restore release hygiene, signal
+active maintenance to anyone comparing us with cypress-rails.
+
+Contents: Rails 8.1 compat (#207), generator whitespace (#205), PR #210
+(RAILS_ENV respected), PR #168 (Playwright JSON response fix).
+
+Tasks (each independently implementable; IDs referenced below):
+
+- **R1 — Merge PR #210.** Verify CI green on a rebase against master first.
+  Changelog entry under `### Changed`: server no longer overrides a
+  pre-set `RAILS_ENV`.
+- **R2 — Rebase + merge PR #168.** Conflict is in
+  `lib/generators/cypress_on_rails/templates/spec/e2e/e2e_helper.rb.erb` area
+  (playwright helper templates). After rebase, run the Playwright example app
+  CI job. Note in CHANGELOG under `### Fixed`. Credit @helio3197.
+- **R3 — CHANGELOG pass.** Move the `[Unreleased]` folder-structure section
+  (#201/#203) under `## [1.20.0]` — verified: commit 73961af is inside the
+  v1.20.0 tag but its entry was left under Unreleased. Add entries for
+  #205, #207, #210, #168.
+- **R4 — Release.** Follow `RELEASING.md` (`rake release[1.21.0]`,
+  gem-release based). Requires RubyGems + git push credentials (human step).
+- **R5 — Backfill GitHub Releases** for v1.16.0, v1.17.0, v1.18.0, v1.19.0,
+  v1.20.0, v1.21.0 from CHANGELOG sections
+  (`gh release create v1.XX.0 --title "vX.XX.0" --notes-file <extract>`).
+  Rationale: the repo currently advertises "Latest release v1.15.0 · 2023" —
+  reads as abandoned, which is fatal when courting cypress-rails refugees.
+- **R6 — Fix the release task** (PR #191's goal) only if R4 actually hits the
+  duplicate-task conflict; otherwise close #191 and note the finding.
+
+### v1.22.0 — "the cypress-rails magnet" (target: +4–6 weeks)
+
+Theme: harden the server/transactional path, then actively convert
+cypress-rails users.
+
+- **H1 (issue #185) — server & state-reset hardening.** `priority: high`.
+  Scope from the issue: spawn-failure error handling, SIGTERM→SIGKILL
+  escalation with timeout, port-detection retry, process-group cleanup, and
+  tests for `lib/cypress_on_rails/server.rb` +
+  `lib/cypress_on_rails/state_reset_middleware.rb`. Acceptance: new specs
+  covering each failure mode; multi-threaded Puma smoke test in one example
+  app (this is the exact failure mode that killed cypress-rails — see
+  testdouble/cypress-rails#164).
+- **H2 (issue #186) — PR #180 review follow-ups.** Small; do with H1.
+- **H3 (issue #13) — security hardening.** Add an opt-in shared-secret token
+  check to the middleware (`c.middleware_token = ENV[...]`; requests without
+  the header 403) + README warning rewrite. Do NOT enable middleware outside
+  dev/test by default (already the case — `use_middleware = !Rails.env.production?`;
+  VERIFY current default in `lib/cypress_on_rails/configuration.rb`).
+- **M1 — `docs/MIGRATE_FROM_CYPRESS_RAILS.md`.** The centerpiece. Structure:
+  1. Why (dormant since 2024, Rails 7.2+ broken, no Playwright — with links);
+  2. Concept map table (their env vars/hooks/reset endpoint → ours; most map 1:1 since v1.19.0);
+  3. Step-by-step swap (Gemfile, generator, initializer);
+  4. What you gain (factories from JS, `appEval`, scenarios, VCR, Playwright);
+  5. Honest trade-offs (middleware security model + mitigation from H3).
+  Acceptance: a real cypress-rails example app converted by following only the
+  guide, committed under `specs_e2e/` as a CI job if practical.
+- **M2 — README repositioning.** Add "Migrating from cypress-rails" link near
+  the top; add a short comparison table; move the ShakaCode consulting block
+  below the fold (match current react_on_rails/shakapacker style); add badges
+  (gem version, downloads, CI).
+- **M3 — Outreach (human, not agent):** ShakaCode blog post
+  ("cypress-rails is stuck on Rails 7.1 — here's the maintained path, with
+  Playwright"), a respectful comment on testdouble/cypress-rails#164
+  pointing to M1, Reddit/r/rails + Rails Discord, changelog.com pitch.
+- **M4 — Test-env docs (issue #157, PRs #173/#210).** Document the two
+  supported modes (dev-env with `ENV['CYPRESS']` vs test-env with code
+  reloading enabled) in README + `docs/`; then close #157 and resolve #173.
+
+### v1.23.0 — "agent-native E2E" (target: +2–3 months)
+
+Theme: make this the E2E layer AI agents reach for — aligned with
+ShakaStack's "most agent-capable stack" claim. E2E-with-app-state-control is
+uniquely agent-friendly: an agent can seed state via `app_commands`, run one
+spec headlessly, and get a deterministic pass/fail without clicking around.
+
+- **A1 — `AGENTS.md`** (contributor-facing; mirror
+  react_on_rails/AGENTS.md structure; reuse shakacode/agent-workflows seams).
+- **A2 — `AGENTS_USER_GUIDE.md` + `llms.txt`** (user-facing: how an agent in a
+  host app should install, generate, seed state, run one test headlessly,
+  interpret failures; publish llms.txt wherever docs land per S2).
+- **A3 — `rails g cypress_on_rails:doctor` or `rake cypress_on_rails:doctor`.**
+  Checks: middleware mounted? install_folder exists & matches config? VCR
+  middleware on if vcr commands present (would have prevented issue #175)?
+  server bootable? Print actionable fixes. Convention match: react_on_rails
+  doctor / shakapacker doctor.
+- **A4 (issue #78) — TypeScript declarations** for `cy.app*` commands, shipped
+  via generator or `@types/`-style package. `agent-ready`.
+- **A5 — machine-readable failure output.** Ensure middleware errors return
+  structured JSON (error class, message, backtrace head) so agents can
+  self-correct; document in A2.
+- Candidates from backlog as capacity allows: #80 (devise helper),
+  #81 (mailer deliveries endpoint), #114 (document/benchmark transactional mode
+  vs database_cleaner).
+
+---
+
+## 4. ShakaStack integration (parallel track, mostly non-repo work)
+
+- **S1 — shakastack.com:** add cypress-playwright-on-rails as a Projects card
+  and extend "Prove" to two legs: *prove it's fast* (ShakaPerf) + *prove it
+  works* (this gem). Owner: whoever edits shakastack.com (site repo UNKNOWN —
+  locate first).
+- **S2 — docs-site decision (needs @justin808):** dedicated domain
+  (cypressplaywrightonrails.com? testing.shakastack.com?) vs polished in-repo
+  docs. Every sibling project has a domain; recommendation: cheap
+  subdomain-on-shakastack option to start.
+- **S3 — cross-promotion:** react_on_rails already uses this gem for its E2E
+  suite — write that up (blog or docs page "How React on Rails tests itself
+  with Playwright"), link from react_on_rails docs and AGENTS_USER_GUIDE.
+- **S4 — naming decision (needs @justin808, closes #11/#24):** repo is
+  `cypress-playwright-on-rails`, gem is `cypress-on-rails`, brand is split.
+  Options: (a) status quo, (b) rename gem with alias. Recommendation: (a) for
+  now — 6.4M downloads of brand equity; revisit only with a 2.0.
+
+---
+
+## 5. Decisions needed from @justin808
+
+1. Approve merge order R1/R2 and the v1.21.0 scope.
+2. Approve closing the 7 close-candidates (§2) with the prescribed comments.
+3. Close or keep #24 (gem split) and #11 (rename) — recommendation: close both.
+4. Docs-site decision (S2).
+5. Outreach tone for the cypress-rails#164 comment (M3) — draft before posting.
+6. Whether #191/#193 (release task, RuboCop) land before or after v1.21.0
+   (recommendation: after, to keep the release diff minimal).
+
+## 6. Suggested agent execution order
+
+```
+R3 → R1 → R2 → R4(human) → R5        # v1.21.0, ~1 day of agent work + release
+H1 → H2 → H3 → M1 → M2 → M4          # hardening before marketing
+A1 → A2 → A3 → A4 → A5               # agent-native layer
+S1–S4 in parallel (site/marketing, human-led)
+```
+
+Every task above states its issue/PR, files, and acceptance criteria; tasks
+labeled `agent-ready` on GitHub carry the same contract. When in doubt:
+small PRs, `bundle exec rubocop` clean, CHANGELOG entry per user-visible
+change, files end with newline.

--- a/docs/roadmap/2026-07-release-and-adoption-plan.md
+++ b/docs/roadmap/2026-07-release-and-adoption-plan.md
@@ -1,7 +1,37 @@
 # Release & Adoption Plan — July 2026
 
-Status: PROPOSED (triage applied to GitHub 2026-07-03; everything else awaits maintainer sign-off)
+Status: APPROVED & IN EXECUTION (decisions approved by @justin808 2026-07-04)
 Owner: @justin808
+
+## Execution log
+
+- 2026-07-03: triage labels applied to all open issues/PRs.
+- 2026-07-04: **R1 done** (PR #210 merged). **R2 done** (PR #168 rebased as
+  PR #219, merged; obsolete Rails 4.2 commit dropped). **R5 done** (GitHub
+  Releases v1.16.0–v1.20.0 backfilled; repo now shows v1.20.0 as Latest).
+  **R3 in review** (PR #225). All 7 close-candidates closed with pointers,
+  plus #24 and #11 closed per decision. Every remaining open issue now
+  carries an "Agent Implementation Spec" section. New task issues:
+  [#220](https://github.com/shakacode/cypress-playwright-on-rails/issues/220) (M1 migration guide),
+  [#221](https://github.com/shakacode/cypress-playwright-on-rails/issues/221) (M2 README),
+  [#222](https://github.com/shakacode/cypress-playwright-on-rails/issues/222) (A1+A2 agent docs),
+  [#223](https://github.com/shakacode/cypress-playwright-on-rails/issues/223) (A3 doctor),
+  [#224](https://github.com/shakacode/cypress-playwright-on-rails/issues/224) (M3 outreach, gated).
+- Remaining for v1.21.0: merge PR #225, then a maintainer runs
+  `rake release[1.21.0]` (RELEASING.md) and publishes the GitHub Release.
+
+## Decisions (2026-07-04, @justin808)
+
+1. v1.21.0 scope and R1/R2 merge order — **approved, executed**.
+2. Seven close-candidates — **approved, closed**.
+3. #24 (gem split) and #11 (rename) — **closed**.
+4. Docs site (S2) — **testing.shakastack.com for now**; buy a dedicated
+   domain only if/when the naming question resolves toward a rename.
+   Gem naming: long-term rename is attractive for discoverability
+   (Playwright missing from the name); under active consideration — see §S4.
+5. Outreach (M3) — approved in principle; post only after v1.21.0 +
+   hardening (#185) + migration guide (#220) ship. Draft lives in #224.
+6. #191/#193 (release task, RuboCop) — **after** v1.21.0.
 Audience: maintainers **and coding agents**. Every task below is written to be
 implementable by an agent without additional context. Facts were verified on
 2026-07-03; re-verify anything marked VERIFY before acting on it.

--- a/docs/roadmap/2026-07-release-and-adoption-plan.md
+++ b/docs/roadmap/2026-07-release-and-adoption-plan.md
@@ -158,24 +158,17 @@ Contents: Rails 8.1 compat (#207), generator whitespace (#205), PR #210
 
 Tasks (each independently implementable; IDs referenced below):
 
-- **R1 — Merge PR #210.** Verify CI green on a rebase against master first.
-  Changelog entry under `### Changed`: server no longer overrides a
-  pre-set `RAILS_ENV`.
-- **R2 — Rebase + merge PR #168.** Conflict is in
-  `lib/generators/cypress_on_rails/templates/spec/e2e/e2e_helper.rb.erb` area
-  (playwright helper templates). After rebase, run the Playwright example app
-  CI job. Note in CHANGELOG under `### Fixed`. Credit @helio3197.
-- **R3 — CHANGELOG pass.** Move the `[Unreleased]` folder-structure section
-  (#201/#203) under `## [1.20.0]` — verified: commit 73961af is inside the
-  v1.20.0 tag but its entry was left under Unreleased. Add entries for
-  #205, #207, #210, #168.
-- **R4 — Release.** Follow `RELEASING.md` (`rake release[1.21.0]`,
-  gem-release based). Requires RubyGems + git push credentials (human step).
-- **R5 — Backfill GitHub Releases** for v1.16.0, v1.17.0, v1.18.0, v1.19.0,
-  v1.20.0, v1.21.0 from CHANGELOG sections
-  (`gh release create v1.XX.0 --title "vX.XX.0" --notes-file <extract>`).
-  Rationale: the repo currently advertises "Latest release v1.15.0 · 2023" —
-  reads as abandoned, which is fatal when courting cypress-rails refugees.
+- **R1 — Merge PR #210.** ✅ DONE 2026-07-04.
+- **R2 — Rebase + merge PR #168.** ✅ DONE 2026-07-04 as PR #219 (fork
+  rejected maintainer push; obsolete Rails 4.2 Gemfile commit dropped).
+- **R3 — CHANGELOG pass.** ✅ DONE 2026-07-04 (PR #225): #201/#203 entry moved
+  under `## [1.20.0]`; Unreleased now lists #205, #207, #210, #219.
+- **R4 — Release.** ⏳ REMAINING (human step): follow `RELEASING.md`
+  (`rake release[1.21.0]`, gem-release based); requires RubyGems + git push
+  credentials. Then `gh release create v1.21.0` from the CHANGELOG section.
+- **R5 — Backfill GitHub Releases.** ✅ DONE 2026-07-04 for v1.16.0–v1.20.0;
+  repo now shows v1.20.0 as Latest (was v1.15.0 · 2023). v1.21.0's release
+  is created as part of R4.
 - **R6 — Fix the release task** (PR #191's goal) only if R4 actually hits the
   duplicate-task conflict; otherwise close #191 and note the finding.
 
@@ -252,37 +245,37 @@ spec headlessly, and get a deterministic pass/fail without clicking around.
   and extend "Prove" to two legs: *prove it's fast* (ShakaPerf) + *prove it
   works* (this gem). Owner: whoever edits shakastack.com (site repo UNKNOWN —
   locate first).
-- **S2 — docs-site decision (needs @justin808):** dedicated domain
-  (cypressplaywrightonrails.com? testing.shakastack.com?) vs polished in-repo
-  docs. Every sibling project has a domain; recommendation: cheap
-  subdomain-on-shakastack option to start.
+- **S2 — docs site (DECIDED 2026-07-04):** publish to
+  **testing.shakastack.com**; no dedicated domain unless/until the 2.0 rename
+  ships (see ADR-0001). Implementation task: stand up the docs site there
+  once #221 (README/docs split) lands, and publish `llms.txt` from #222.
 - **S3 — cross-promotion:** react_on_rails already uses this gem for its E2E
   suite — write that up (blog or docs page "How React on Rails tests itself
   with Playwright"), link from react_on_rails docs and AGENTS_USER_GUIDE.
-- **S4 — naming decision (needs @justin808, closes #11/#24):** repo is
-  `cypress-playwright-on-rails`, gem is `cypress-on-rails`, brand is split.
-  Options: (a) status quo, (b) rename gem with alias. Recommendation: (a) for
-  now — 6.4M downloads of brand equity; revisit only with a 2.0.
+- **S4 — naming (DECIDED 2026-07-04, ADR-0001; #11/#24 closed):** publish
+  `e2e_on_rails` now as a thin alias gem (issue #226); full rename — canonical
+  gem `e2e_on_rails`, module `E2eOnRails`, `cypress-on-rails` as shim — at
+  2.0. See `docs/adr/0001-reserve-e2e_on_rails-rename-at-2.0.md` and
+  `CONTEXT.md` for the canonical vocabulary.
 
 ---
 
-## 5. Decisions needed from @justin808
+## 5. Open decisions
 
-1. Approve merge order R1/R2 and the v1.21.0 scope.
-2. Approve closing the 7 close-candidates (§2) with the prescribed comments.
-3. Close or keep #24 (gem split) and #11 (rename) — recommendation: close both.
-4. Docs-site decision (S2).
-5. Outreach tone for the cypress-rails#164 comment (M3) — draft before posting.
-6. Whether #191/#193 (release task, RuboCop) land before or after v1.21.0
-   (recommendation: after, to keep the release diff minimal).
+All six original decision points were resolved on 2026-07-04 (see the
+Decisions section at the top of this document). Still genuinely open:
+
+1. Final sign-off on the M3 outreach comment text before posting (draft in
+   issue #224; gated on v1.21.0 + #185 + #220 shipping).
+2. Timing of the 2.0 rename flip (deliberately unscheduled — ADR-0001).
 
 ## 6. Suggested agent execution order
 
-```
-R3 → R1 → R2 → R4(human) → R5        # v1.21.0, ~1 day of agent work + release
-H1 → H2 → H3 → M1 → M2 → M4          # hardening before marketing
-A1 → A2 → A3 → A4 → A5               # agent-native layer
-S1–S4 in parallel (site/marketing, human-led)
+```text
+R4(human release)                     # only v1.21.0 step left
+#226 alias gem → H1 → H2 → H3 → M1 → M2 → M4   # hardening before marketing
+A1 → A2 → A3 → A4 → A5                # agent-native layer (issues #222/#223/#78)
+S1–S3 in parallel (site/marketing, human-led)
 ```
 
 Every task above states its issue/PR, files, and acceptance criteria; tasks

--- a/docs/roadmap/2026-07-release-and-adoption-plan.md
+++ b/docs/roadmap/2026-07-release-and-adoption-plan.md
@@ -25,10 +25,11 @@ Owner: @justin808
 1. v1.21.0 scope and R1/R2 merge order — **approved, executed**.
 2. Seven close-candidates — **approved, closed**.
 3. #24 (gem split) and #11 (rename) — **closed**.
-4. Docs site (S2) — **testing.shakastack.com for now**; buy a dedicated
-   domain only if/when the naming question resolves toward a rename.
-   Gem naming: long-term rename is attractive for discoverability
-   (Playwright missing from the name); under active consideration — see §S4.
+4. Docs site (S2) — **testing.shakastack.com for now**; no domain purchase
+   until the 2.0 rename ships. Gem naming — **RESOLVED 2026-07-04
+   (ADR-0001)**: publish `e2e_on_rails` now as a thin alias/wrapper gem;
+   full rename (canonical gem `e2e_on_rails`, module `E2eOnRails`,
+   `cypress-on-rails` as shim) happens at 2.0. Supersedes §S4's option list.
 5. Outreach (M3) — approved in principle; post only after v1.21.0 +
    hardening (#185) + migration guide (#220) ship. Draft lives in #224.
 6. #191/#193 (release task, RuboCop) — **after** v1.21.0.


### PR DESCRIPTION
## Summary

Adds `docs/roadmap/2026-07-release-and-adoption-plan.md` — an implementation-ready roadmap covering:

- **Triage results**: all 21 open issues + 6 open PRs labeled on 2026-07-03 with a new label set (`priority: *`, `agent-ready`, `cypress-rails-parity`, `close-candidate`, `needs-info`, `needs-rebase`, `needs-decision`, `security`, `ci-infra`, `documentation`), including 7 close-candidates resolved by v1.18–1.20.
- **v1.21.0 release plan**: flush 9 months of unreleased fixes (Rails 8.1 compat #207, generator whitespace #205), merge PRs #210 and #168, fix the CHANGELOG misplacement of the #201/#203 entry, and backfill GitHub Releases v1.16–v1.21 (repo currently advertises v1.15.0 / 2023 as "latest").
- **cypress-rails adoption campaign (v1.22.0)**: testdouble/cypress-rails has been dormant since Sept 2024 and is broken on Rails 7.2+ (their #164), stranding an active user base; v1.19.0 already shipped the parity features they need. Plan: harden the server/state-reset path first (#185/#186/#13), then ship a migration guide + outreach.
- **Agent-native E2E (v1.23.0)**: AGENTS.md, AGENTS_USER_GUIDE.md + llms.txt, a doctor task, TypeScript typings (#78), structured error output — aligning with react_on_rails conventions and the ShakaStack "most agent-capable stack" positioning.
- **ShakaStack integration**: the gem is currently absent from shakastack.com/shakacode.com; proposes adding it as the "prove it works" leg of Build → Deploy → Prove, plus the react_on_rails dogfooding story.
- **Decisions needed** from @justin808 (§5): close-candidate approvals, docs-site domain, #11/#24 disposition, outreach tone.

Every task has an ID, scope, files, and acceptance criteria so coding agents can pick them up independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the July 2026 Release & Adoption Plan to “APPROVED & IN EXECUTION,” with refreshed execution status, triage outcomes, and revised release milestones for upcoming versions.
  * Published **CONTEXT.md** to standardize canonical vocabulary and naming conventions.
  * Added **ADR-0001** documenting the branding/gem-rename approach, including the immediate wrapper strategy and the deferred canonical switch for the 2.0 release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->