### PR TITLE
Fix Playwright e2e helpers to return parsed JSON instead of Buffer

### DIFF
--- a/lib/generators/cypress_on_rails/templates/spec/playwright/support/on-rails.js
+++ b/lib/generators/cypress_on_rails/templates/spec/playwright/support/on-rails.js
@@ -8,7 +8,7 @@ const appCommands = async (data) => {
   const response = await context.post('/__e2e__/command', { data })
 
   expect(response.ok()).toBeTruthy()
-  return response.body
+  return response.json();
 }
 
 const app = (name, options = {}) => appCommands({ name, options }).then((body) => body[0])
@@ -23,7 +23,7 @@ const appVcrInsertCassette = async (cassette_name, options) => {
   Object.keys(options).forEach(key => options[key] === undefined ? delete options[key] : {});
   const response = await context.post("/__e2e__/vcr/insert", {data: [cassette_name,options]});
   expect(response.ok()).toBeTruthy();
-  return response.body;
+  return response.json();
 }
 
 const appVcrEjectCassette = async () => {
@@ -31,7 +31,7 @@ const appVcrEjectCassette = async () => {
 
   const response = await context.post("/__e2e__/vcr/eject");
   expect(response.ok()).toBeTruthy();
-  return response.body;
+  return response.json();
 }
 
 export { appCommands, app, appScenario, appEval, appFactories, appVcrInsertCassette, appVcrEjectCassette }


### PR DESCRIPTION
## Summary

Rebase of #168 by @helio3197 (the fork branch does not allow maintainer edits, so this replacement PR carries the commit; authorship is preserved on the commit itself).

Playwright helper templates (`appCommands`, `appVcrInsertCassette`, `appVcrEjectCassette`) returned `response.body`, which in Playwright's `APIResponse` is a `Promise<Buffer>` — so `cy`-style consumers like `app('clean')` received a Buffer instead of parsed JSON. All three now return `response.json()`, matching the middleware, which always responds with `Content-Type: application/json` (verified in `lib/cypress_on_rails/middleware.rb` and `lib/cypress_on_rails/vcr/insert_eject_middleware.rb`).

The original PR's second commit (pinning `bigdecimal` in `specs_e2e/rails_4_2/Gemfile`) was dropped: the Rails 4.2 example app was removed from master in v1.18.0.

Closes #168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command and cassette helper responses to return parsed JSON instead of raw response bodies.
  * Made support behavior more consistent when inserting or ejecting cassettes.
  * Adjusted minor formatting around the updated helper flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->