### PR TITLE
Restructure CHANGELOG for v1.21.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,24 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Fixed
+* **Rails 8.1 compatibility**: Require ActiveSupport delegation explicitly so the railtie loads under Rails 8.1. [PR 207](https://github.com/shakacode/cypress-playwright-on-rails/pull/207)
+* **Playwright helpers return parsed JSON**: `appCommands`, `appVcrInsertCassette`, and `appVcrEjectCassette` in the generated Playwright `on-rails.js` now return `response.json()` instead of a `Buffer`. [PR 219](https://github.com/shakacode/cypress-playwright-on-rails/pull/219) by [helio3197](https://github.com/helio3197) (originally [PR 168](https://github.com/shakacode/cypress-playwright-on-rails/pull/168))
+* Generated initializer and `e2e_helper.rb` templates no longer contain trailing spaces. [PR 205](https://github.com/shakacode/cypress-playwright-on-rails/pull/205) by [tnir](https://github.com/tnir)
+
+### Changed
+* The managed test server no longer overrides `RAILS_ENV` when it is already set, so E2E runs can target the test (or any) environment. [PR 210](https://github.com/shakacode/cypress-playwright-on-rails/pull/210) by [arielj](https://github.com/arielj)
+
+---
+
+## [1.20.0] - 2025-10-21
+[Compare](https://github.com/shakacode/cypress-playwright-on-rails/compare/v1.19.0...v1.20.0)
+
+### Fixed
 * **BREAKING: Generator folder structure**: Fixed install generator to create `e2e_helper.rb` and `app_commands/` at the install folder root (e.g., `e2e/`) instead of inside the framework subdirectory (e.g., `e2e/cypress/`). This ensures compatibility between Cypress/Playwright config file location and middleware expectations. [#201]
+
+### Changed
+* Improved server process cleanup and readiness checks. [PR 199](https://github.com/shakacode/cypress-playwright-on-rails/pull/199)
+* Gem description now mentions Playwright support. [PR 200](https://github.com/shakacode/cypress-playwright-on-rails/pull/200)
 
 ### Migration Guide for Folder Structure Change
 


### PR DESCRIPTION
## Summary

Roadmap task **R3** (docs/roadmap/2026-07-release-and-adoption-plan.md), pre-release housekeeping for v1.21.0:

- The **BREAKING generator folder-structure fix (#201/#203) actually shipped in v1.20.0** (commit 73961af is inside the v1.20.0 tag) but its CHANGELOG entry — including the migration guide — was left under `[Unreleased]`. It now lives under a proper `## [1.20.0] - 2025-10-21` header, alongside previously missing 1.20.0 entries (#199 server cleanup, #200 gem description).
- `[Unreleased]` now lists exactly what v1.21.0 will ship: Rails 8.1 compat (#207), Playwright helpers returning parsed JSON (#219, originally #168 by @helio3197), template whitespace fix (#205 by @tnir), and the server respecting a pre-set `RAILS_ENV` (#210 by @arielj).

After this merges, master is ready for `rake release[1.21.0]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
