### PR TITLE
Port ShakaCode release flow

### DIFF
--- a/.agents/agent-workflow.yml
+++ b/.agents/agent-workflow.yml
@@ -1,0 +1,9 @@
+# Non-command agent-workflow configuration for portable shared skills.
+base_branch: master
+changelog: "CHANGELOG.md - user-visible changes only; version-stamp via bundle exec rake update_changelog[release|rc|beta|VERSION]; PR links use [PR N](https://github.com/shakacode/cypress-playwright-on-rails/pull/N) by [username](https://github.com/username)."
+follow_up_prefix: "Follow-up:"
+review_gate: "Ruby workflow green on the PR, local bundle exec rake evidence, and all review threads resolved."
+approval_exempt: "docs, workflow text, helper scripts, and focused release-process edits with tests."
+coordination_backend: "private shakacode/agent-coordination (claims/heartbeats namespaced by full repo name)"
+hosted_ci_trigger: "CI runs on every PR."
+ci_parity_environment: "Use .github/workflows/ruby.yml; reproduce failures with bundle exec rake plus the matching specs_e2e/*/test.sh job when needed."

--- a/.claude/commands/update-changelog.md
+++ b/.claude/commands/update-changelog.md
@@ -1,224 +1,71 @@
 # Update Changelog
 
-You are helping to add an entry to the CHANGELOG.md file for the Cypress on Rails project.
+You are helping update `CHANGELOG.md` for `shakacode/cypress-playwright-on-rails`.
 
-## Critical Requirements
+## Arguments
 
-1. **User-visible changes only**: Only add changelog entries for user-visible changes:
+This command accepts an optional argument: `$ARGUMENTS`
 
-   - New features
-   - Bug fixes
-   - Breaking changes
-   - Deprecations
-   - Performance improvements
-   - Security fixes
-   - Changes to public APIs or configuration options
+- No argument: add missing user-visible entries to `## [Unreleased]`.
+- `release`: add entries, then stamp the next stable version with `bundle exec rake update_changelog[release]`.
+- `rc`: add entries, then stamp the next release candidate with `bundle exec rake update_changelog[rc]`.
+- `beta`: add entries, then stamp the next beta with `bundle exec rake update_changelog[beta]`.
+- Explicit version such as `1.21.0.rc.0`: add entries, then stamp that exact version with `bundle exec rake update_changelog[1.21.0.rc.0]`.
 
-2. **Do NOT add entries for**:
-   - Linting fixes
-   - Code formatting
-   - Internal refactoring
-   - Test updates
-   - Documentation fixes (unless they fix incorrect docs about behavior)
-   - CI/CD changes
-
-## Formatting Requirements
-
-### Entry Format
-
-Each changelog entry MUST follow this exact format:
-
-```markdown
-- **Bold description of change**. [PR 1818](https://github.com/shakacode/cypress-on-rails/pull/1818) by [username](https://github.com/username). Optional additional context or details.
-```
-
-**Important formatting rules**:
-
-- Start with a dash and space: `- `
-- Use **bold** for the main description
-- End the bold description with a period before the link
-- Always link to the PR: `[PR 1818](https://github.com/shakacode/cypress-on-rails/pull/1818)` - **NO hash symbol**
-- Always link to the author: `by [username](https://github.com/username)`
-- End with a period after the author link
-- Additional details can be added after the main entry, using proper indentation for multi-line entries
-
-### Breaking Changes Format
-
-For breaking changes, use this format:
-
-```markdown
-- **Feature Name**: Description of the breaking change. See migration guide below. [PR 1818](https://github.com/shakacode/cypress-on-rails/pull/1818) by [username](https://github.com/username).
-
-**Migration Guide:**
-
-1. Step one
-2. Step two
-```
-
-### Category Organization
-
-Entries should be organized under these section headings. The project uses both standard and custom headings:
-
-**Standard headings** (from keepachangelog.com) - use these for most changes:
-
-- `#### Added` - New features
-- `#### Changed` - Changes to existing functionality
-- `#### Deprecated` - Deprecation notices
-- `#### Removed` - Removed features
-- `#### Fixed` - Bug fixes
-- `#### Security` - Security-related changes
-- `#### Improved` - Improvements to existing features
-
-**Custom headings** (project-specific) - use sparingly when standard headings don't fit:
-
-- `#### Breaking Changes` - Breaking changes with migration guides
-- `#### API Improvements` - API changes and improvements
-- `#### Developer Experience` - Developer workflow improvements
-- `#### Generator Improvements` - Generator-specific changes
-- `#### Performance` - Performance improvements
-
-**Prefer standard headings.** Only use custom headings when the change needs more specific categorization.
-
-**Only include section headings that have entries.**
-
-### Version Management
-
-After adding entries, use the rake task to manage version headers:
+After the changelog PR merges, the release task reads the newest stamped changelog version automatically:
 
 ```bash
-bundle exec rake update_changelog
+bundle exec rake release
 ```
 
-This will:
+## Core Rules
 
-- Add headers for the new version
-- Update version diff links at the bottom of the file
+- Add entries only for user-visible changes: features, bug fixes, breaking changes, deprecations, performance improvements, security fixes, and public API/configuration changes.
+- Skip linting, formatting, internal refactors, test-only changes, CI changes, and docs-only changes unless the docs correct public behavior.
+- Do not ask the user for PR details. Use git history and GitHub.
+- Use the repo's current changelog shape:
+  - Version headers: `## [1.21.0.rc.0] - YYYY-MM-DD`
+  - Category headings: `### Added`, `### Changed`, `### Improved`, `### Fixed`, etc.
+  - PR links: `[PR 219](https://github.com/shakacode/cypress-playwright-on-rails/pull/219) by [username](https://github.com/username)`.
 
-## Process
+## Release Flow
 
-### For Regular Changelog Updates
+1. Fetch current branch, base branch, and tags:
 
-1. **Determine the correct version tag to compare against**:
+   ```bash
+   git fetch origin master --tags
+   ```
 
-   - First, check the tag dates: `git log --tags --simplify-by-decoration --pretty="format:%ai %d" | head -10`
-   - Find the latest version tag and its date
-   - Compare main branch date to the tag date
-   - If the tag is NEWER than main, it means main needs to be updated to include the tag's commits
-   - **CRITICAL**: Always use `git log TAG..BRANCH` to find commits that are in the tag but not in the branch, as the tag may be ahead
+2. Inspect merged PRs since the latest release tag:
 
-2. **Check commits and version boundaries**:
+   ```bash
+   git tag -l 'v*' --sort=-v:refname | head -10
+   git log --oneline LATEST_TAG..origin/master
+   ```
 
-   - Run `git log --oneline LAST_TAG..master` to see commits since the last release
-   - Also check `git log --oneline master..LAST_TAG` to see if the tag is ahead of master
-   - If the tag is ahead, entries in "Unreleased" section may actually belong to that tagged version
-   - Identify which commits contain user-visible changes
-   - Extract PR numbers and author information from commit messages
-   - **Never ask the user for PR details** - get them from the git history
+3. Add missing user-visible entries under `## [Unreleased]`, merging into existing category headings.
 
-3. **Validate** that changes are user-visible (per the criteria above). If not user-visible, skip those commits.
+4. If `$ARGUMENTS` asks for a release stamp, run the rake task:
 
-4. **Read the current CHANGELOG.md** to understand the existing structure and formatting.
+   ```bash
+   bundle exec rake update_changelog[release]
+   bundle exec rake update_changelog[rc]
+   bundle exec rake update_changelog[beta]
+   bundle exec rake update_changelog[1.21.0.rc.0]
+   ```
 
-5. **Determine where entries should go**:
+5. Verify:
 
-   - If the latest version tag is NEWER than master branch, move entries from "Unreleased" to that version section
-   - If master is ahead of the latest tag, add new entries to "Unreleased"
-   - Always verify the version date in CHANGELOG.md matches the actual tag date
+   ```bash
+   bundle exec rake
+   ```
 
-6. **Add or move entries** to the appropriate section under appropriate category headings.
+6. Commit the changelog update on a branch and open a PR. Once merged, release with:
 
-   - **CRITICAL**: When moving entries from "Unreleased" to a version section, merge them with existing entries under the same category heading
-   - **NEVER create duplicate section headings** (e.g., don't create two "### Fixed" sections)
-   - If the version section already has a category heading (e.g., "### Fixed"), add the moved entries to that existing section
-   - Maintain the category order as defined above
+   ```bash
+   git switch master
+   git pull --ff-only
+   bundle exec rake release
+   ```
 
-7. **Verify formatting**:
-
-   - Bold description with period
-   - Proper PR link (NO hash symbol)
-   - Proper author link
-   - Consistent with existing entries
-   - File ends with a newline character
-
-8. **Show the user** the added or moved entries and explain what was done.
-
-### For Beta to Non-Beta Version Release
-
-When releasing from beta to a stable version (e.g., v2.1.0-beta.3 → v2.1.0):
-
-1. **Remove all beta version labels** from the changelog:
-
-   - Change `### [v2.1.0-beta.1]`, `### [v2.1.0-beta.2]`, etc. to a single `### [v2.1.0]` section
-   - Combine all beta entries into the stable release section
-
-2. **Consolidate duplicate entries**:
-
-   - If bug fixes or changes were made to features introduced in earlier betas, keep only the final state
-   - Remove redundant changelog entries for fixes to beta features
-   - Keep the most recent/accurate description of each change
-
-3. **Update version diff links** using `bundle exec rake update_changelog`
-
-### For New Beta Version Release
-
-When creating a new beta version, ask the user which approach to take:
-
-**Option 1: Process changes since last beta**
-
-- Only add entries for commits since the previous beta version
-- Maintains detailed history of what changed in each beta
-
-**Option 2: Collapse all prior betas into current beta**
-
-- Combine all beta changelog entries into the new beta version
-- Removes previous beta version sections
-- Cleaner changelog with less version noise
-
-After the user chooses, proceed with that approach.
-
-## Examples
-
-Run this command to see real formatting examples from the codebase:
-
-```bash
-grep -A 3 "^#### " CHANGELOG.md | head -30
-```
-
-### Good Entry Example
-
-```markdown
-- **Support for Playwright**: Added support for Playwright browser automation framework alongside Cypress. The gem now works with both Cypress and Playwright test suites. [PR 123](https://github.com/shakacode/cypress-on-rails/pull/123) by [username](https://github.com/username).
-```
-
-### Entry with Sub-bullets Example
-
-```markdown
-- **Enhanced Factory Bot Integration**: Improved factory bot integration with new configuration options:
-  - `factory_bot_fixture_path`: Configurable directory for factory bot fixtures (default: "spec/fixtures")
-  - `enable_factory_bot_cleanup`: Automatically clean up factory bot data after each test (default: true) [PR 456](https://github.com/shakacode/cypress-on-rails/pull/456) by [username](https://github.com/username)
-```
-
-### Breaking Change Example
-
-```markdown
-- **Ruby Version Requirement**: Minimum Ruby version increased from 2.5 to 2.7 to align with Rails 7 requirements. Ruby 2.5 and 2.6 are no longer supported.
-
-**Migration Guide:**
-
-To upgrade to this version:
-
-1. Update your Ruby version to 2.7 or higher:
-   rbenv install 2.7.0
-
-2. Update your Gemfile to specify the minimum Ruby version:
-   ruby '>= 2.7.0'
-```
-
-## Additional Notes
-
-- Keep descriptions concise but informative
-- Focus on the "what" and "why", not the "how"
-- Use past tense for the description
-- Be consistent with existing formatting in the changelog
-- Always ensure the file ends with a trailing newline
-- See CHANGELOG.md for additional formatting examples
+The release task bumps `lib/cypress_on_rails/version.rb`, updates `Gemfile.lock`, commits, tags, pushes, publishes the gem, and creates or updates the GitHub release from the stamped changelog section.

--- a/.claude/commands/update-changelog.md
+++ b/.claude/commands/update-changelog.md
@@ -48,10 +48,10 @@ bundle exec rake release
 4. If `$ARGUMENTS` asks for a release stamp, run the rake task:
 
    ```bash
-   bundle exec rake update_changelog[release]
-   bundle exec rake update_changelog[rc]
-   bundle exec rake update_changelog[beta]
-   bundle exec rake update_changelog[1.21.0.rc.0]
+   bundle exec rake "update_changelog[release]"
+   bundle exec rake "update_changelog[rc]"
+   bundle exec rake "update_changelog[beta]"
+   bundle exec rake "update_changelog[1.21.0.rc.0]"
    ```
 
 5. Verify:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,200 +1,112 @@
 # Release Process
 
-This document describes how to release a new version of cypress-playwright-on-rails.
+This project follows the ShakaCode release shape used by Shakapacker and React on Rails:
+update and stamp the changelog first, merge that PR, then run the release task with no version argument.
 
 ## Prerequisites
 
-1. Maintainer access to the repository
-2. RubyGems account with publish permissions for `cypress-on-rails`
-3. Clean working directory on `master` branch
-4. Development dependencies installed: `bundle install`
-   - Includes `gem-release` for gem management (like react_on_rails)
+1. Maintainer access to `shakacode/cypress-playwright-on-rails`.
+2. RubyGems publish access for `cypress-on-rails`.
+3. Authenticated GitHub CLI with write access: `gh auth status`.
+4. Clean checkout on `master`.
+5. Dependencies installed: `bundle install`.
 
-## Release Command
+## Recommended Flow
 
-The project uses a single rake task to automate the entire release process:
+1. Update and stamp the changelog in a PR:
 
-```bash
-rake release[VERSION,DRY_RUN]
-```
-
-### Examples
-
-```bash
-# Release version 1.19.0
-rake release[1.19.0]
-
-# Automatic patch version bump (e.g., 1.18.0 -> 1.18.1)
-rake release
-
-# Dry run to preview what would happen
-rake release[1.19.0,true]
-```
-
-### What the Release Task Does
-
-The `rake release` task will:
-
-1. Pull latest changes from master
-2. Bump the version in `lib/cypress_on_rails/version.rb`
-3. Update `Gemfile.lock` via `bundle install`
-4. Commit the version bump and Gemfile.lock changes
-5. Create a git tag (e.g., `v1.19.0`)
-6. Push the commit and tag to GitHub
-7. Build and publish the gem to RubyGems (will prompt for OTP)
-
-### Post-Release Steps
-
-After publishing, complete these manual steps:
-
-1. **Update CHANGELOG.md**
    ```bash
-   bundle exec rake update_changelog
-   git commit -a -m 'Update CHANGELOG.md'
-   git push
+   # For a stable release
+   /update-changelog release
+
+   # For a release candidate
+   /update-changelog rc
+
+   # Or explicitly
+   /update-changelog 1.21.0.rc.0
    ```
 
-2. **Create GitHub Release**
-   - Go to the releases page: https://github.com/shakacode/cypress-playwright-on-rails/releases
-   - Click on the newly created tag
-   - Copy release notes from CHANGELOG.md
-   - Publish the release
+   The command should add user-visible entries to `## [Unreleased]`, then run the matching rake task:
 
-3. **Announce the Release** (optional)
-   - Post in Slack channel
-   - Tweet about the release
-   - Update forum posts if needed
+   ```bash
+   bundle exec rake update_changelog[release]
+   bundle exec rake update_changelog[rc]
+   bundle exec rake update_changelog[1.21.0.rc.0]
+   ```
+
+2. Merge the changelog PR.
+
+3. Release from an up-to-date `master`:
+
+   ```bash
+   git switch master
+   git pull --ff-only
+   bundle exec rake release
+   ```
+
+   With no version argument, `rake release` reads the newest version header in `CHANGELOG.md`.
+
+## Useful Commands
+
+```bash
+# Dry run using the changelog-stamped version
+bundle exec rake "release[,true]"
+
+# Explicit version
+bundle exec rake "release[1.21.0.rc.0]"
+
+# Override version-policy checks, only when intentional
+bundle exec rake "release[1.21.0,false,true]"
+
+# Re-sync GitHub release notes from CHANGELOG.md
+bundle exec rake "sync_github_release[1.21.0]"
+```
+
+## What `rake release` Does
+
+1. Verifies the worktree is clean.
+2. Verifies GitHub CLI auth and repository write access.
+3. Resolves the release version from `CHANGELOG.md`, or falls back to a patch bump.
+4. Validates the requested version is newer than existing tags and matches the changelog bump shape for stable releases.
+5. Bumps `lib/cypress_on_rails/version.rb`.
+6. Runs `bundle install` to update `Gemfile.lock`.
+7. Commits the release metadata.
+8. Creates and pushes `vVERSION`.
+9. Publishes the gem to RubyGems.
+10. Creates or updates the GitHub release from that version's `CHANGELOG.md` section.
+
+Dry runs use a temporary git worktree so the main checkout is not dirtied.
 
 ## Version Numbering
 
-Follow [Semantic Versioning](https://semver.org/):
-
-- **MAJOR** (X.0.0): Breaking changes
-- **MINOR** (1.X.0): New features, backwards compatible
-- **PATCH** (1.19.X): Bug fixes, backwards compatible
-
-### Examples
-
-```bash
-# Patch release (bug fixes)
-rake release[1.18.1]
-
-# Minor release (new features)
-rake release[1.19.0]
-
-# Major release (breaking changes)
-rake release[2.0.0]
-
-# Automatic patch bump
-rake release
-```
-
-## Pre-Release Checklist
-
-Before running `rake release`:
-
-- [ ] All PRs for the release are merged
-- [ ] CI is passing on master
-- [ ] CHANGELOG.md has [Unreleased] section with all changes
-- [ ] Major changes have been tested manually
-- [ ] Documentation is up to date
+- Major: breaking changes.
+- Minor: backward-compatible features.
+- Patch: backward-compatible fixes.
+- Prerelease: use RubyGems dot notation, such as `1.21.0.rc.0` or `1.21.0.beta.0`.
 
 ## Troubleshooting
 
-### "Must be on master branch" error
+### Missing changelog section
+
+Run `/update-changelog release`, `/update-changelog rc`, or:
 
 ```bash
-git checkout master
-git pull --rebase
+bundle exec rake update_changelog[1.21.0.rc.0]
 ```
 
-### "Working directory is not clean" error
+### RubyGems publish failure
+
+Fix authentication or OTP issues, then retry from the same checkout:
 
 ```bash
-# Commit or stash your changes
-git status
-git add -A && git commit -m "Your message"
-# or
-git stash
+gem release
+bundle exec rake "sync_github_release[VERSION]"
 ```
 
+### Version policy failure
 
-### "Failed to push gem to RubyGems" error
-
-Ensure you're authenticated with RubyGems:
-```bash
-gem signin
-# Enter your RubyGems credentials
-```
-
-### Tag already exists
-
-If you need to re-release the same version:
-```bash
-# Delete local tag
-git tag -d v1.19.0
-
-# Delete remote tag
-git push origin :v1.19.0
-
-# Reset to before the release commit
-git reset --hard HEAD~1
-
-# Try the release again
-rake release[1.19.0]
-```
-
-## Rollback
-
-If you need to rollback a release:
-
-### Yank the gem from RubyGems
-```bash
-gem yank cypress-on-rails -v 1.19.0
-```
-
-### Delete the git tag
-```bash
-git tag -d v1.19.0
-git push origin :v1.19.0
-```
-
-### Revert the version commit
-```bash
-git revert HEAD
-git push origin master
-```
-
-## Example Release Flow
+Confirm the latest git tags and changelog headings. If the release is intentionally unusual:
 
 ```bash
-# 1. Ensure you're on master and up to date
-git checkout master
-git pull --rebase
-
-# 2. Check CI is passing
-# Visit: https://github.com/shakacode/cypress-playwright-on-rails/actions
-
-# 3. Release (will handle everything automatically)
-rake release[1.19.0]
-# Enter your RubyGems OTP when prompted
-
-# 4. Update the changelog
-bundle exec rake update_changelog
-git commit -a -m 'Update CHANGELOG.md'
-git push
-
-# 5. Create GitHub release
-open "https://github.com/shakacode/cypress-playwright-on-rails/releases"
-# Click on the new tag, add release notes from CHANGELOG.md
-
-# 6. Celebrate! 🎉
+RELEASE_VERSION_POLICY_OVERRIDE=true bundle exec rake release
 ```
-
-## Notes
-
-- The release task handles all git operations (commit, tag, push) automatically
-- Always ensure CI is green before releasing
-- The task will fail fast if working directory is not clean
-- Failed releases can be retried after fixing issues
-- Use dry run mode (`rake release[VERSION,true]`) to preview changes

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -84,6 +84,17 @@ Dry runs use a temporary git worktree so the main checkout is not dirtied.
 - Patch: backward-compatible fixes.
 - Prerelease: use RubyGems dot notation, such as `1.21.0.rc.0` or `1.21.0.beta.0`.
 
+## Release Candidate Smoke Targets
+
+Before promoting a release candidate to stable, validate it against downstream apps that exercise the generated Cypress and Playwright helpers:
+
+- `shakacode/cypress-playwright-on-rails`: run the full gem test suite and Rails matrix.
+- `shakacode/react_on_rails`: bump `react_on_rails/Gemfile.development_dependencies` and run the dummy app E2E checks.
+- `shakacode/react-on-rails-demos`: bump `packages/shakacode_demo_common/shakacode_demo_common.gemspec`, then run the `basic-v16-webpack` and `basic-v16-rspack` demo E2E checks.
+- Private ShakaCode production apps that already use the gem should smoke-test the release candidate before the stable release.
+
+React on Rails source-backed demos listed on https://reactonrails.com/examples/ should be added to this list as they adopt `cypress-on-rails`.
+
 ## Troubleshooting
 
 ### Missing changelog section

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -29,9 +29,9 @@ update and stamp the changelog first, merge that PR, then run the release task w
    The command should add user-visible entries to `## [Unreleased]`, then run the matching rake task:
 
    ```bash
-   bundle exec rake update_changelog[release]
-   bundle exec rake update_changelog[rc]
-   bundle exec rake update_changelog[1.21.0.rc.0]
+   bundle exec rake "update_changelog[release]"
+   bundle exec rake "update_changelog[rc]"
+   bundle exec rake "update_changelog[1.21.0.rc.0]"
    ```
 
 2. Merge the changelog PR.
@@ -55,7 +55,8 @@ bundle exec rake "release[,true]"
 # Explicit version
 bundle exec rake "release[1.21.0.rc.0]"
 
-# Override version-policy checks, only when intentional
+# Override version-policy checks, only when intentional.
+# The rake argument and RELEASE_VERSION_POLICY_OVERRIDE=true are equivalent.
 bundle exec rake "release[1.21.0,false,true]"
 
 # Re-sync GitHub release notes from CHANGELOG.md
@@ -69,7 +70,7 @@ bundle exec rake "sync_github_release[1.21.0]"
 3. Resolves the release version from `CHANGELOG.md`, or falls back to a patch bump.
 4. Validates the requested version is newer than existing tags and matches the changelog bump shape for stable releases.
 5. Bumps `lib/cypress_on_rails/version.rb`.
-6. Runs `bundle install` to update `Gemfile.lock`.
+6. Runs `bundle install` to verify dependencies.
 7. Commits the release metadata.
 8. Creates and pushes `vVERSION`.
 9. Publishes the gem to RubyGems.
@@ -102,7 +103,7 @@ React on Rails source-backed demos listed on https://reactonrails.com/examples/ 
 Run `/update-changelog release`, `/update-changelog rc`, or:
 
 ```bash
-bundle exec rake update_changelog[1.21.0.rc.0]
+bundle exec rake "update_changelog[1.21.0.rc.0]"
 ```
 
 ### RubyGems publish failure

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,124 +1,23 @@
 # Release Process
 
-This document describes how to release a new version of the `cypress-on-rails` gem.
+Release notes are prepared before publishing.
 
-## Prerequisites
-
-1. Install the `gem-release` gem globally:
-   ```bash
-   gem install gem-release
-   ```
-
-2. Ensure you have write access to the rubygems.org package
-
-3. Set up two-factor authentication (2FA) for RubyGems and have your OTP generator ready
-
-## Release Steps
-
-### 1. Prepare for Release
-
-Ensure your working directory is clean:
-```bash
-git status
-```
-
-If you have uncommitted changes, commit or stash them first.
-
-### 2. Pull Latest Changes
+1. Run `/update-changelog release`, `/update-changelog rc`, or `/update-changelog VERSION`.
+2. Merge the changelog PR.
+3. From a clean, current `master`, run:
 
 ```bash
-git pull --rebase
+bundle exec rake release
 ```
 
-### 3. Run the Release Task
+The release task reads the newest stamped `CHANGELOG.md` version, bumps the gem version, commits, tags, pushes, publishes to RubyGems, and syncs the GitHub release from the changelog section.
 
-To release a specific version:
-```bash
-rake release[1.19.0]
-```
-
-To automatically bump the patch version:
-```bash
-rake release
-```
-
-To perform a dry run (without actually publishing):
-```bash
-rake release[1.19.0,true]
-```
-
-### 4. Enter Your OTP
-
-When prompted, enter your one-time password (OTP) from your authenticator app for RubyGems.
-
-If you get an error during gem publishing, you can run `gem release` manually to retry.
-
-### 5. Update the CHANGELOG
-
-After successfully publishing the gem, update the CHANGELOG:
+Useful variants:
 
 ```bash
-bundle exec rake update_changelog
-# This will:
-# - Add a new version header with the release date
-# - Add version comparison links
-# - Prompt you to move content from [Unreleased] to the new version
-
-# Edit CHANGELOG.md to move unreleased changes to the new version section
-git commit -a -m 'Update CHANGELOG.md'
-git push
+bundle exec rake "release[,true]"          # dry run
+bundle exec rake "release[1.21.0.rc.0]"    # explicit version
+bundle exec rake "sync_github_release[1.21.0.rc.0]"
 ```
 
-## Version Numbering
-
-Follow [Semantic Versioning](https://semver.org/):
-
-- **Major version** (X.0.0): Breaking changes
-- **Minor version** (0.X.0): New features, backwards compatible
-- **Patch version** (0.0.X): Bug fixes, backwards compatible
-- **Pre-release versions**: Use dot notation, not dashes (e.g., `2.0.0.beta.1`, not `2.0.0-beta.1`)
-
-## What the Release Task Does
-
-The release task automates the following steps:
-
-1. Checks for uncommitted changes (will abort if found)
-2. Pulls the latest changes from the repository
-3. Bumps the version number in `lib/cypress_on_rails/version.rb` using `gem bump`
-4. Creates a git commit with the version bump message
-5. Creates a git tag for the new version (e.g., `v1.19.0`)
-6. Pushes the commit to GitHub
-7. Pushes the tag to GitHub
-8. Builds the gem
-9. Publishes the gem to RubyGems (requires OTP)
-
-## Troubleshooting
-
-### Authentication Error
-
-If you get an authentication error with RubyGems:
-1. Verify your OTP is correct and current
-2. Ensure your RubyGems API key is valid
-3. Run `gem release` manually to retry
-
-### Version Already Exists
-
-If the version already exists on RubyGems:
-1. Bump to a higher version number
-2. Or fix the version in `lib/cypress_on_rails/version.rb` and try again
-
-### Uncommitted Changes Error
-
-If you have uncommitted changes:
-1. Review your changes with `git status`
-2. Commit them with `git commit -am "Your message"`
-3. Or stash them with `git stash`
-4. Then retry the release
-
-## Post-Release
-
-After releasing:
-
-1. Announce the release on relevant channels (Slack, forum, etc.)
-2. Update any documentation that references version numbers
-3. Consider creating a GitHub release with release notes
+Prereleases use RubyGems dot notation, for example `1.21.0.rc.0`.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -22,9 +22,4 @@ bundle exec rake "sync_github_release[1.21.0.rc.0]"
 
 Prereleases use RubyGems dot notation, for example `1.21.0.rc.0`.
 
-Before promoting a release candidate to stable, smoke-test public downstreams that already use the gem:
-
-- `shakacode/react_on_rails`
-- `shakacode/react-on-rails-demos`
-
-Also smoke-test private ShakaCode production apps that use the gem. Add React on Rails demos from https://reactonrails.com/examples/ as they adopt `cypress-on-rails`.
+For maintainer prerequisites, RC smoke targets, and troubleshooting, see `RELEASING.md`.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -21,3 +21,10 @@ bundle exec rake "sync_github_release[1.21.0.rc.0]"
 ```
 
 Prereleases use RubyGems dot notation, for example `1.21.0.rc.0`.
+
+Before promoting a release candidate to stable, smoke-test public downstreams that already use the gem:
+
+- `shakacode/react_on_rails`
+- `shakacode/react-on-rails-demos`
+
+Also smoke-test private ShakaCode production apps that use the gem. Add React on Rails demos from https://reactonrails.com/examples/ as they adopt `cypress-on-rails`.

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -140,6 +140,10 @@ def prerelease_gem_version?(gem_version)
   gem_version.to_s.match?(/\A\d+\.\d+\.\d+\.(beta|rc)\.\d+\z/i)
 end
 
+def prerelease_base_gem_version(gem_version)
+  gem_version.to_s.sub(/\.(beta|rc)\.\d+\z/i, "")
+end
+
 def parse_release_tag_to_gem_version(tag)
   stable_match = tag.to_s.match(/\Av(\d+\.\d+\.\d+)\z/)
   return stable_match[1] if stable_match
@@ -188,6 +192,17 @@ end
 
 def version_policy_override_enabled?(override_flag)
   release_truthy?(override_flag) || release_truthy?(ENV.fetch("RELEASE_VERSION_POLICY_OVERRIDE", nil))
+end
+
+def stable_prerelease_promotion?(tagged_versions:, target_gem_version:, latest_stable_version:)
+  return false if prerelease_gem_version?(target_gem_version)
+  return false unless Gem::Version.new(target_gem_version) > Gem::Version.new(latest_stable_version)
+
+  tagged_versions.any? do |version|
+    prerelease_gem_version?(version) &&
+      prerelease_base_gem_version(version) == target_gem_version &&
+      Gem::Version.new(version) > Gem::Version.new(latest_stable_version)
+  end
 end
 
 def handle_version_policy_violation!(message:, allow_override:)
@@ -248,6 +263,15 @@ def validate_release_version_policy!(gem_root:, target_gem_version:, allow_overr
 
   if prerelease_gem_version?(target_gem_version)
     puts "VERSION POLICY: Skipping changelog bump-consistency check for prerelease #{target_gem_version}."
+    return
+  end
+
+  if stable_prerelease_promotion?(
+    tagged_versions: tagged_versions,
+    target_gem_version: target_gem_version,
+    latest_stable_version: latest_stable_version
+  )
+    puts "VERSION POLICY: Skipping changelog bump-consistency check for stable promotion of prerelease #{target_gem_version}."
     return
   end
 

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -7,15 +7,8 @@ require "rubygems/version"
 require "shellwords"
 require "tempfile"
 require "tmpdir"
-require_relative "task_helpers"
 
 GITHUB_REPO_SLUG_PATTERN = /\A[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\z/ unless defined?(GITHUB_REPO_SLUG_PATTERN)
-
-class RaisingMessageHandler
-  def add_error(error)
-    raise error
-  end
-end
 
 def release_truthy?(value)
   [true, "true", "yes", 1, "1", "t"].include?(value.instance_of?(String) ? value.downcase : value)
@@ -186,6 +179,7 @@ end
 def expected_bump_type_from_changelog_section(changelog_section)
   section = changelog_section.to_s
   return :major if section.match?(/^###\s+(?:WARNING:\s*)?Breaking(?:\s+Changes?)?\b/i)
+  return :major if section.match?(/^\s*[-*]\s+(?:\*\*)?BREAKING\b/i)
   return :minor if section.match?(/^###\s+(Added|New\s+Features?|Features?|Enhancements?)\b/i)
   return :patch if section.match?(/^###\s+(Fixed|Fixes|Bug\s+Fixes?|Security|Improved|Changed|Deprecated|Removed)\b/i)
 
@@ -206,6 +200,8 @@ def handle_version_policy_violation!(message:, allow_override:)
 end
 
 def extract_changelog_section(changelog_path:, version:)
+  return nil unless File.exist?(changelog_path)
+
   lines = File.readlines(changelog_path)
   section_header = /^## \[(?:v)?#{Regexp.escape(version)}\]/
   start_index = lines.index { |line| line.match?(section_header) }
@@ -476,6 +472,7 @@ def perform_release(gem_version:, dry_run:, check_uncommitted: true, allow_versi
     validate_requested_version_input!(version_input)
     current_version = current_gem_version(release_root)
     target_version = compute_target_gem_version(current_gem_version: current_version, version_input: version_input)
+    version_already_current = target_version == current_version
 
     warn_changelog_missing(gem_root: release_root, version: target_version)
     validate_release_version_policy!(
@@ -485,21 +482,29 @@ def perform_release(gem_version:, dry_run:, check_uncommitted: true, allow_versi
       fetch_tags: true
     )
 
-    sh_in_dir_for_release(
-      release_root,
-      "gem bump --no-commit --file lib/cypress_on_rails/version.rb --version #{Shellwords.escape(target_version)}"
-    )
-    sh_in_dir_for_release(release_root, "bundle install")
+    unless version_already_current
+      sh_in_dir_for_release(
+        release_root,
+        "gem bump --no-commit --file lib/cypress_on_rails/version.rb --version #{Shellwords.escape(target_version)}"
+      )
+      sh_in_dir_for_release(release_root, "bundle install")
+    end
 
     actual_version = current_gem_version(release_root)
     released_gem_version = actual_version
     abort "Expected gem bump to produce #{target_version}, but found #{actual_version}." unless actual_version == target_version
 
     if dry_run
-      puts "DRY RUN: Would commit #{staged_files.join(', ')}, tag v#{actual_version}, push, and release gem."
+      if version_already_current
+        puts "DRY RUN: Would tag v#{actual_version}, push, and release gem from the current commit."
+      else
+        puts "DRY RUN: Would commit #{staged_files.join(', ')}, tag v#{actual_version}, push, and release gem."
+      end
     else
-      sh_in_dir_for_release(release_root, "git add #{Shellwords.join(staged_files)}")
-      sh_in_dir_for_release(release_root, "git commit -m #{Shellwords.escape("Release v#{actual_version}")}")
+      unless version_already_current
+        sh_in_dir_for_release(release_root, "git add #{Shellwords.join(staged_files)}")
+        sh_in_dir_for_release(release_root, "git commit -m #{Shellwords.escape("Release v#{actual_version}")}")
+      end
       sh_in_dir_for_release(release_root, "git tag v#{actual_version}")
       sh_in_dir_for_release(release_root, "git push && git push --tags")
       puts "Carefully add your OTP for RubyGems. If you get an error, run 'gem release' again."

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -432,8 +432,7 @@ end
 
 def release_staged_files
   [
-    "lib/cypress_on_rails/version.rb",
-    "Gemfile.lock"
+    "lib/cypress_on_rails/version.rb"
   ]
 end
 
@@ -467,13 +466,16 @@ def perform_release(gem_version:, dry_run:, check_uncommitted: true, allow_versi
 
   verify_gh_auth(gem_root: gem_root) unless dry_run
 
-  validate_requested_version_input!(gem_version.to_s.strip)
+  raw_version_input = gem_version.to_s.strip
+  validate_requested_version_input!(raw_version_input) unless raw_version_input.empty?
 
   with_release_checkout(gem_root: gem_root, dry_run: dry_run) do |release_root|
     sh_in_dir_for_release(release_root, "git pull --rebase") unless dry_run
 
+    version_input = resolve_version_input(raw_version_input, release_root)
+    validate_requested_version_input!(version_input)
     current_version = current_gem_version(release_root)
-    target_version = compute_target_gem_version(current_gem_version: current_version, version_input: gem_version)
+    target_version = compute_target_gem_version(current_gem_version: current_version, version_input: version_input)
 
     warn_changelog_missing(gem_root: release_root, version: target_version)
     validate_release_version_policy!(
@@ -550,11 +552,9 @@ task :release, %i[gem_version dry_run override_version_policy] do |_t, args|
   args_hash = args.to_hash
   is_dry_run = release_truthy?(args_hash[:dry_run])
   allow_override = version_policy_override_enabled?(args_hash[:override_version_policy])
-  gem_root = File.expand_path("..", __dir__)
-  version_input = resolve_version_input(args_hash[:gem_version], gem_root)
 
   release_result = perform_release(
-    gem_version: version_input,
+    gem_version: args_hash[:gem_version].to_s,
     dry_run: is_dry_run,
     allow_version_policy_override: allow_override
   )

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -1,7 +1,15 @@
 # frozen_string_literal: true
 
 require "bundler"
+require "English"
+require "open3"
+require "rubygems/version"
+require "shellwords"
+require "tempfile"
+require "tmpdir"
 require_relative "task_helpers"
+
+GITHUB_REPO_SLUG_PATTERN = /\A[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\z/ unless defined?(GITHUB_REPO_SLUG_PATTERN)
 
 class RaisingMessageHandler
   def add_error(error)
@@ -9,72 +17,563 @@ class RaisingMessageHandler
   end
 end
 
-# rubocop:disable Metrics/BlockLength
+def release_truthy?(value)
+  [true, "true", "yes", 1, "1", "t"].include?(value.instance_of?(String) ? value.downcase : value)
+end
+
+def semver_keyword?(version_input)
+  %w[patch minor major].include?(version_input.to_s.strip.downcase)
+end
+
+def sh_in_dir_for_release(dir, *shell_commands)
+  Dir.chdir(dir) do
+    Bundler.with_unbundled_env do
+      shell_commands.flatten.each do |shell_command|
+        sh(shell_command.strip)
+      end
+    end
+  end
+end
+
+def ensure_clean_worktree!
+  status = `git status --porcelain`
+  return if $CHILD_STATUS.success? && status.empty?
+
+  if $CHILD_STATUS.success?
+    abort "You have uncommitted changes. Please commit or stash them before releasing."
+  end
+
+  abort "Unable to check git status. Please ensure Git is installed and this is a git checkout."
+end
+
+def github_repo_slug(gem_root)
+  origin_url, status = Open3.capture2e("git", "-C", gem_root, "remote", "get-url", "origin")
+  origin_url = origin_url.strip
+  abort "Unable to determine git origin URL for GitHub release checks.\n\n#{origin_url}" unless status.success?
+
+  match = origin_url.match(%r{\Agit@github\.com:(?<repo>[^/]+/[^/]+?)(?:\.git)?\z}) ||
+          origin_url.match(%r{\Assh://git@github\.com/(?<repo>[^/]+/[^/]+?)(?:\.git)?\z}) ||
+          origin_url.match(%r{\Ahttps://(?:[^/@]+@)?github\.com/(?<repo>[^/]+/[^/]+?)(?:\.git)?\z}) ||
+          origin_url.match(%r{\Agit://github\.com/(?<repo>[^/]+/[^/]+?)(?:\.git)?\z}) ||
+          origin_url.match(%r{\Agithub\.com/(?<repo>[^/]+/[^/]+?)(?:\.git)?\z})
+  abort "Unable to determine GitHub repository from origin URL #{origin_url.inspect}" unless match
+
+  repo_slug = match[:repo]
+  abort "GitHub repository slug #{repo_slug.inspect} from origin URL #{origin_url.inspect} is invalid." unless repo_slug.match?(GITHUB_REPO_SLUG_PATTERN)
+
+  repo_slug
+end
+
+def verify_gh_auth(gem_root:)
+  result, status = Open3.capture2e("gh", "auth", "status")
+  abort "GitHub CLI authentication required. Run `gh auth login` and retry.\n\n#{result}" unless status.success?
+
+  repo_slug = github_repo_slug(gem_root)
+  permissions_result, permissions_status = Open3.capture2e("gh", "api", "repos/#{repo_slug}", "--jq", ".permissions.push")
+  abort "GitHub CLI authenticated, but failed to verify write access to #{repo_slug}.\n\n#{permissions_result}" unless permissions_status.success?
+  abort "GitHub CLI authenticated, but your account/token does not have write access to #{repo_slug}." unless permissions_result.strip == "true"
+
+  puts "GitHub CLI authenticated with write access to #{repo_slug}"
+end
+
+def current_gem_version(gem_root)
+  version_file = File.join(gem_root, "lib", "cypress_on_rails", "version.rb")
+  content = File.read(version_file)
+  match = content.match(/VERSION\s*=\s*["']([^"']+)["']/)
+  abort "Unable to read current gem version from #{version_file}" unless match
+
+  match[1]
+end
+
+def normalize_release_version_string(version_or_tag)
+  version = version_or_tag.to_s.strip
+  version = version.delete_prefix("v")
+  version = version.sub(/-(beta|rc)\./i, '.\1.')
+
+  unless version.match?(/\A\d+\.\d+\.\d+(\.(beta|rc)\.\d+)?\z/i)
+    abort "Failed to parse version from #{version_or_tag.inspect}. Expected 1.2.3 or 1.2.3.rc.0."
+  end
+
+  version.downcase
+end
+
+def validate_requested_version_input!(version_input)
+  return if semver_keyword?(version_input)
+  return if version_input.to_s.match?(/\A\d+\.\d+\.\d+(\.(beta|rc)\.\d+)?\z/i)
+
+  abort <<~ERROR
+    Invalid version argument: #{version_input.inspect}
+
+    Use:
+      - Semver bump keyword: patch, minor, or major
+      - Explicit version: 1.21.0
+      - Explicit prerelease: 1.21.0.rc.0
+  ERROR
+end
+
+def parse_gem_version_components(gem_version)
+  match = gem_version.to_s.strip.match(/\A(\d+)\.(\d+)\.(\d+)(?:\.(beta|rc)\.(\d+))?\z/i)
+  abort "Unsupported gem version format: #{gem_version.inspect}" unless match
+
+  {
+    major: match[1].to_i,
+    minor: match[2].to_i,
+    patch: match[3].to_i,
+    prerelease_type: match[4]&.downcase,
+    prerelease_index: match[5]&.to_i
+  }
+end
+
+def compute_target_gem_version(current_gem_version:, version_input:)
+  input = version_input.to_s.strip
+  return normalize_release_version_string(input) unless semver_keyword?(input)
+
+  version = parse_gem_version_components(current_gem_version)
+  case input.downcase
+  when "patch"
+    if version[:prerelease_type]
+      "#{version[:major]}.#{version[:minor]}.#{version[:patch]}"
+    else
+      "#{version[:major]}.#{version[:minor]}.#{version[:patch] + 1}"
+    end
+  when "minor"
+    "#{version[:major]}.#{version[:minor] + 1}.0"
+  when "major"
+    "#{version[:major] + 1}.0.0"
+  end
+end
+
+def prerelease_gem_version?(gem_version)
+  gem_version.to_s.match?(/\A\d+\.\d+\.\d+\.(beta|rc)\.\d+\z/i)
+end
+
+def parse_release_tag_to_gem_version(tag)
+  stable_match = tag.to_s.match(/\Av(\d+\.\d+\.\d+)\z/)
+  return stable_match[1] if stable_match
+
+  prerelease_with_dot = tag.to_s.match(/\Av(\d+\.\d+\.\d+)\.(beta|rc)\.(\d+)\z/i)
+  return "#{prerelease_with_dot[1]}.#{prerelease_with_dot[2].downcase}.#{prerelease_with_dot[3]}" if prerelease_with_dot
+
+  prerelease_with_dash = tag.to_s.match(/\Av(\d+\.\d+\.\d+)-(beta|rc)\.(\d+)\z/i)
+  return "#{prerelease_with_dash[1]}.#{prerelease_with_dash[2].downcase}.#{prerelease_with_dash[3]}" if prerelease_with_dash
+
+  nil
+end
+
+def tagged_release_gem_versions(gem_root, fetch_tags: true)
+  if fetch_tags
+    fetch_output, fetch_status = Open3.capture2e("git", "-C", gem_root, "fetch", "--tags", "--quiet")
+    abort "Unable to fetch tags for version policy validation.\n\n#{fetch_output.strip}" unless fetch_status.success?
+  end
+
+  tags_output, tags_status = Open3.capture2e("git", "-C", gem_root, "tag", "-l", "v*")
+  abort "Unable to list git tags for version policy validation.\n\n#{tags_output.strip}" unless tags_status.success?
+
+  tags_output.lines.map(&:strip).filter_map { |tag| parse_release_tag_to_gem_version(tag) }.uniq
+end
+
+def version_bump_type(previous_stable_gem_version:, target_gem_version:)
+  previous = parse_gem_version_components(previous_stable_gem_version)
+  target = parse_gem_version_components(target_gem_version)
+
+  return :major if target[:major] > previous[:major]
+  return :minor if target[:major] == previous[:major] && target[:minor] > previous[:minor]
+  return :patch if target[:major] == previous[:major] && target[:minor] == previous[:minor] && target[:patch] > previous[:patch]
+
+  :none
+end
+
+def expected_bump_type_from_changelog_section(changelog_section)
+  section = changelog_section.to_s
+  return :major if section.match?(/^###\s+(?:WARNING:\s*)?Breaking(?:\s+Changes?)?\b/i)
+  return :minor if section.match?(/^###\s+(Added|New\s+Features?|Features?|Enhancements?)\b/i)
+  return :patch if section.match?(/^###\s+(Fixed|Fixes|Bug\s+Fixes?|Security|Improved|Changed|Deprecated|Removed)\b/i)
+
+  nil
+end
+
+def version_policy_override_enabled?(override_flag)
+  release_truthy?(override_flag) || release_truthy?(ENV.fetch("RELEASE_VERSION_POLICY_OVERRIDE", nil))
+end
+
+def handle_version_policy_violation!(message:, allow_override:)
+  if allow_override
+    puts "VERSION POLICY OVERRIDE enabled: #{message}"
+    return
+  end
+
+  abort message
+end
+
+def extract_changelog_section(changelog_path:, version:)
+  lines = File.readlines(changelog_path)
+  section_header = /^## \[(?:v)?#{Regexp.escape(version)}\]/
+  start_index = lines.index { |line| line.match?(section_header) }
+  return nil unless start_index
+
+  end_index = ((start_index + 1)...lines.length).find { |idx| lines[idx].start_with?("## [") || lines[idx].start_with?("---") } || lines.length
+  section = lines[(start_index + 1)...end_index].join.strip
+  section.empty? ? nil : section
+end
+
+def validate_release_version_policy!(gem_root:, target_gem_version:, allow_override:, fetch_tags: true)
+  tagged_versions = tagged_release_gem_versions(gem_root, fetch_tags: fetch_tags)
+  latest_tagged_version = tagged_versions.max_by { |version| Gem::Version.new(version) }
+
+  if latest_tagged_version && Gem::Version.new(target_gem_version) <= Gem::Version.new(latest_tagged_version)
+    handle_version_policy_violation!(
+      message: "Requested version #{target_gem_version} must be greater than latest tagged version #{latest_tagged_version}.",
+      allow_override: allow_override
+    )
+  end
+
+  if prerelease_gem_version?(target_gem_version) && latest_tagged_version
+    target = parse_gem_version_components(target_gem_version)
+    latest = parse_gem_version_components(latest_tagged_version)
+    same_release_base = target[:major] == latest[:major] && target[:minor] == latest[:minor] && target[:patch] == latest[:patch]
+    return if same_release_base && prerelease_gem_version?(latest_tagged_version)
+  end
+
+  latest_stable_version = tagged_versions.reject { |version| prerelease_gem_version?(version) }
+                                         .max_by { |version| Gem::Version.new(version) }
+  return unless latest_stable_version
+
+  actual_bump_type = version_bump_type(
+    previous_stable_gem_version: latest_stable_version,
+    target_gem_version: target_gem_version
+  )
+  if actual_bump_type == :none
+    handle_version_policy_violation!(
+      message: "Requested version #{target_gem_version} is not a major/minor/patch bump over latest stable #{latest_stable_version}.",
+      allow_override: allow_override
+    )
+    return if allow_override
+  end
+
+  if prerelease_gem_version?(target_gem_version)
+    puts "VERSION POLICY: Skipping changelog bump-consistency check for prerelease #{target_gem_version}."
+    return
+  end
+
+  changelog_section = extract_changelog_section(
+    changelog_path: File.join(gem_root, "CHANGELOG.md"),
+    version: target_gem_version
+  )
+  unless changelog_section
+    puts "VERSION POLICY: No changelog content found for #{target_gem_version}; skipping changelog bump-consistency check."
+    return
+  end
+
+  expected_bump_type = expected_bump_type_from_changelog_section(changelog_section)
+  unless expected_bump_type
+    puts "VERSION POLICY: CHANGELOG section #{target_gem_version} does not declare bump level; skipping changelog bump-consistency check."
+    return
+  end
+  return if actual_bump_type == expected_bump_type
+
+  handle_version_policy_violation!(
+    message: "Version bump mismatch for #{target_gem_version}: CHANGELOG implies #{expected_bump_type}, but version bump is #{actual_bump_type} from #{latest_stable_version}.",
+    allow_override: allow_override
+  )
+end
+
+def extract_latest_changelog_version(gem_root:)
+  changelog_path = File.join(gem_root, "CHANGELOG.md")
+  return nil unless File.exist?(changelog_path)
+
+  File.readlines(changelog_path).each do |line|
+    match = line.match(/^## \[([^\]]+)\]/)
+    next unless match
+    next if match[1].casecmp("Unreleased").zero?
+
+    return normalize_release_version_string(match[1])
+  end
+
+  nil
+end
+
+def version_tagged?(gem_root, version)
+  system("git", "-C", gem_root, "rev-parse", "--verify", "--quiet", "refs/tags/v#{version}", out: File::NULL, err: File::NULL)
+end
+
+def resolve_version_input(version_input, gem_root)
+  input = version_input.to_s.strip
+  return input unless input.empty?
+
+  changelog_version = extract_latest_changelog_version(gem_root: gem_root)
+  current_version = current_gem_version(gem_root)
+
+  if changelog_version && Gem::Version.new(changelog_version) > Gem::Version.new(current_version)
+    puts "Found CHANGELOG.md version: #{changelog_version} (current: #{current_version})"
+    return changelog_version
+  end
+
+  if changelog_version == current_version && !version_tagged?(gem_root, changelog_version)
+    puts "Using current CHANGELOG.md version: #{changelog_version} (untagged retry)"
+    return changelog_version
+  end
+
+  puts "No new version found in CHANGELOG.md (latest: #{changelog_version || 'none'}, current: #{current_version})."
+  puts "Falling back to patch bump."
+  "patch"
+end
+
+def warn_changelog_missing(gem_root:, version:)
+  section = extract_changelog_section(changelog_path: File.join(gem_root, "CHANGELOG.md"), version: version)
+  return if section
+
+  puts "WARNING: No CHANGELOG.md section found for #{version}."
+  puts "Run /update-changelog before releasing so GitHub release notes can be created automatically."
+end
+
+def ensure_git_tag_exists!(gem_root:, tag:)
+  fetch_output, fetch_status = Open3.capture2e("git", "-C", gem_root, "fetch", "--tags", "--quiet")
+  abort "Unable to fetch git tags before verifying #{tag.inspect}.\n\n#{fetch_output.strip}" unless fetch_status.success?
+
+  tag_exists = system("git", "-C", gem_root, "rev-parse", "--verify", "--quiet", "refs/tags/#{tag}", out: File::NULL, err: File::NULL)
+  abort "Git tag #{tag.inspect} was not found locally or remotely. Verify the tag exists before syncing GitHub release." unless tag_exists
+end
+
+def github_release_command(gem_root: nil, release_context:, notes_file_path:, probe_existing: true)
+  create_command = [
+    "gh", "release", "create", release_context[:tag], "--verify-tag",
+    "--title", release_context[:title], "--notes-file", notes_file_path
+  ]
+  create_command << "--prerelease" if release_context[:prerelease]
+  return create_command unless probe_existing
+
+  abort "Internal error: github_release_command requires gem_root when probe_existing is true." unless gem_root
+
+  release_exists = system("gh", "release", "view", release_context[:tag], chdir: gem_root, out: File::NULL, err: File::NULL)
+  abort "Unable to run `gh`. Ensure GitHub CLI is installed and on PATH." if release_exists.nil?
+
+  if release_exists
+    ["gh", "release", "edit", release_context[:tag], "--title", release_context[:title],
+     "--notes-file", notes_file_path, "--prerelease=#{release_context[:prerelease]}"]
+  else
+    create_command
+  end
+end
+
+def sync_github_release_after_publish(gem_root:, gem_version:, dry_run:, changelog_section: nil)
+  section = changelog_section || extract_changelog_section(
+    changelog_path: File.join(gem_root, "CHANGELOG.md"),
+    version: gem_version
+  )
+
+  unless section
+    puts "Skipping GitHub release: no CHANGELOG.md section for #{gem_version}."
+    puts "After adding the changelog section, run:"
+    puts "bundle exec rake \"sync_github_release[#{gem_version}]\""
+    return
+  end
+
+  release_context = {
+    notes: section,
+    prerelease: prerelease_gem_version?(gem_version),
+    tag: "v#{gem_version}",
+    title: "v#{gem_version}"
+  }
+
+  publish_or_update_github_release(gem_root: gem_root, release_context: release_context, dry_run: dry_run)
+end
+
+def publish_or_update_github_release(gem_root:, release_context:, dry_run:)
+  ensure_git_tag_exists!(gem_root: gem_root, tag: release_context[:tag])
+
+  if dry_run
+    preview_command = github_release_command(
+      release_context: release_context,
+      notes_file_path: "release-notes-file",
+      probe_existing: false
+    )
+    puts "DRY RUN: Would create or update GitHub release #{release_context[:tag]}#{release_context[:prerelease] ? ' (prerelease)' : ''}"
+    puts "DRY RUN: Would run: #{Shellwords.join(preview_command)}"
+    return
+  end
+
+  Tempfile.create(["cypress-on-rails-release-notes-", ".md"]) do |tmp|
+    tmp.write(release_context[:notes])
+    tmp.flush
+
+    release_command = github_release_command(
+      gem_root: gem_root,
+      release_context: release_context,
+      notes_file_path: tmp.path
+    )
+
+    puts "Publishing GitHub release #{release_context[:tag]}#{release_context[:prerelease] ? ' (prerelease)' : ''}"
+    success = system(*release_command, chdir: gem_root)
+    abort "Failed to publish GitHub release #{release_context[:tag]}." unless success
+  end
+end
+
+def with_release_checkout(gem_root:, dry_run:)
+  return yield(gem_root) unless dry_run
+
+  Dir.mktmpdir("cypress-on-rails-release-dry-run") do |tmpdir|
+    worktree_dir = File.join(tmpdir, "worktree")
+    escaped_worktree_dir = Shellwords.escape(worktree_dir)
+
+    sh_in_dir_for_release(gem_root, "git worktree add --detach #{escaped_worktree_dir} HEAD")
+    begin
+      yield(worktree_dir)
+    ensure
+      original_error = $ERROR_INFO
+      begin
+        sh_in_dir_for_release(gem_root, "git worktree remove --force #{escaped_worktree_dir}")
+      rescue Exception => cleanup_error # rubocop:disable Lint/RescueException
+        warn "Failed to remove dry-run release worktree #{worktree_dir}: #{cleanup_error.message}"
+        raise cleanup_error unless original_error
+      end
+    end
+  end
+end
+
+def release_staged_files
+  [
+    "lib/cypress_on_rails/version.rb",
+    "Gemfile.lock"
+  ]
+end
+
+def print_release_summary(release_result)
+  released_version = release_result[:released_gem_version]
+  dry_run = release_result[:dry_run]
+  changelog_section_found = release_result[:changelog_section_found]
+
+  puts "\n#{'=' * 80}"
+  puts(dry_run ? "DRY RUN COMPLETE" : "RELEASE COMPLETE")
+  puts "=" * 80
+
+  if dry_run
+    puts "Version would be bumped to: #{released_version}"
+    puts "Files that would be updated:"
+    release_result.fetch(:staged_files, []).each { |file| puts "  - #{file}" }
+    puts "Changelog: #{changelog_section_found ? 'CHANGELOG.md section found' : 'No CHANGELOG.md section found'}"
+    puts "To actually release, run: bundle exec rake \"release[#{released_version}]\""
+  else
+    puts "Published cypress-on-rails #{released_version} to RubyGems."
+    puts(changelog_section_found ? "GitHub release synced from CHANGELOG.md." : "GitHub release not synced because CHANGELOG.md section was missing.")
+  end
+end
+
+def perform_release(gem_version:, dry_run:, check_uncommitted: true, allow_version_policy_override: false)
+  ensure_clean_worktree! if check_uncommitted
+  gem_root = File.expand_path("..", __dir__)
+  released_gem_version = nil
+  changelog_section_found = false
+  staged_files = release_staged_files
+
+  verify_gh_auth(gem_root: gem_root) unless dry_run
+
+  validate_requested_version_input!(gem_version.to_s.strip)
+
+  with_release_checkout(gem_root: gem_root, dry_run: dry_run) do |release_root|
+    sh_in_dir_for_release(release_root, "git pull --rebase") unless dry_run
+
+    current_version = current_gem_version(release_root)
+    target_version = compute_target_gem_version(current_gem_version: current_version, version_input: gem_version)
+
+    warn_changelog_missing(gem_root: release_root, version: target_version)
+    validate_release_version_policy!(
+      gem_root: release_root,
+      target_gem_version: target_version,
+      allow_override: allow_version_policy_override,
+      fetch_tags: true
+    )
+
+    sh_in_dir_for_release(
+      release_root,
+      "gem bump --no-commit --file lib/cypress_on_rails/version.rb --version #{Shellwords.escape(target_version)}"
+    )
+    sh_in_dir_for_release(release_root, "bundle install")
+
+    actual_version = current_gem_version(release_root)
+    released_gem_version = actual_version
+    abort "Expected gem bump to produce #{target_version}, but found #{actual_version}." unless actual_version == target_version
+
+    if dry_run
+      puts "DRY RUN: Would commit #{staged_files.join(', ')}, tag v#{actual_version}, push, and release gem."
+    else
+      sh_in_dir_for_release(release_root, "git add #{Shellwords.join(staged_files)}")
+      sh_in_dir_for_release(release_root, "git commit -m #{Shellwords.escape("Release v#{actual_version}")}")
+      sh_in_dir_for_release(release_root, "git tag v#{actual_version}")
+      sh_in_dir_for_release(release_root, "git push && git push --tags")
+      puts "Carefully add your OTP for RubyGems. If you get an error, run 'gem release' again."
+      sh_in_dir_for_release(release_root, "gem release")
+    end
+  end
+
+  if released_gem_version
+    changelog_section = extract_changelog_section(
+      changelog_path: File.join(gem_root, "CHANGELOG.md"),
+      version: released_gem_version
+    )
+    changelog_section_found = !changelog_section.nil?
+
+    sync_github_release_after_publish(
+      gem_root: gem_root,
+      gem_version: released_gem_version,
+      dry_run: dry_run,
+      changelog_section: changelog_section
+    ) unless dry_run
+  end
+
+  {
+    dry_run: dry_run,
+    released_gem_version: released_gem_version,
+    changelog_section_found: changelog_section_found,
+    staged_files: staged_files
+  }
+end
 
 desc("Releases the gem using the given version.
 
-IMPORTANT: the gem version must be in valid rubygem format (no dashes).
+Recommended flow:
+  1. Run /update-changelog release, /update-changelog rc, or an explicit version.
+  2. Merge the changelog PR.
+  3. Run bundle exec rake release with no args; it reads the version from CHANGELOG.md.
 
-This task depends on the gem-release (ruby gem) which is installed via `bundle install`
+Arguments:
+1st argument: Version in RubyGems format (1.21.0 or 1.21.0.rc.0), semver keyword
+              (patch/minor/major), or blank to use CHANGELOG.md then fall back to patch.
+2nd argument: Dry run when 'true'.
+3rd argument: Override version policy checks when 'true' or RELEASE_VERSION_POLICY_OVERRIDE=true.
 
-1st argument: The new version in rubygem format (no dashes). Pass no argument to
-              automatically perform a patch version bump.
-2nd argument: Perform a dry run by passing 'true' as a second argument.
-
-Note, accept defaults for rubygems options. Script will pause to get 2FA tokens.
-
-Example: `rake release[2.1.0,false]`")
-task :release, %i[gem_version dry_run] do |_t, args|
-  include CypressOnRails::TaskHelpers
-
-  # Check if there are uncommitted changes
-  unless `git status --porcelain`.strip.empty?
-    raise "You have uncommitted changes. Please commit or stash them before releasing."
-  end
-
+Examples:
+  bundle exec rake release
+  bundle exec rake \"release[1.21.0.rc.0]\"
+  bundle exec rake \"release[,true]\"
+")
+task :release, %i[gem_version dry_run override_version_policy] do |_t, args|
   args_hash = args.to_hash
+  is_dry_run = release_truthy?(args_hash[:dry_run])
+  allow_override = version_policy_override_enabled?(args_hash[:override_version_policy])
+  gem_root = File.expand_path("..", __dir__)
+  version_input = resolve_version_input(args_hash[:gem_version], gem_root)
 
-  is_dry_run = args_hash[:dry_run] == 'true'
-
-  gem_version = args_hash.fetch(:gem_version, "")
-
-  # See https://github.com/svenfuchs/gem-release
-  sh_in_dir(gem_root, "git pull --rebase")
-  sh_in_dir(gem_root, "gem bump --no-commit --file lib/cypress_on_rails/version.rb #{gem_version.strip.empty? ? '' : %(--version #{gem_version})}")
-
-  # Read the actual version from the file after bump
-  load File.expand_path("../lib/cypress_on_rails/version.rb", __dir__)
-  actual_version = CypressOnRails::VERSION
-
-  # Update Gemfile.lock files
-  sh_in_dir(gem_root, "bundle install")
-
-  unless is_dry_run
-    # Commit the version bump
-    sh_in_dir(gem_root, "git add lib/cypress_on_rails/version.rb")
-    sh_in_dir(gem_root, "git commit -m \"Release v#{actual_version}\"")
-
-    # Tag the release
-    sh_in_dir(gem_root, "git tag v#{actual_version}")
-
-    # Push the commit and tag
-    sh_in_dir(gem_root, "git push && git push --tags")
-
-    # Release the new gem version
-    puts "Carefully add your OTP for Rubygems. If you get an error, run 'gem release' again."
-    sh_in_dir(gem_root, "gem release")
-  else
-    puts "DRY RUN: Would have committed, tagged v#{actual_version}, pushed, and released gem"
-  end
-
-  msg = <<~MSG
-    Once you have successfully published, run these commands to update CHANGELOG.md:
-
-    bundle exec rake update_changelog
-    git commit -a -m 'Update CHANGELOG.md'
-    git push
-  MSG
-  puts msg
+  release_result = perform_release(
+    gem_version: version_input,
+    dry_run: is_dry_run,
+    allow_version_policy_override: allow_override
+  )
+  print_release_summary(release_result)
 end
 
-# rubocop:enable Metrics/BlockLength
+desc("Creates or updates the GitHub release from CHANGELOG.md for a published version.
+
+Arguments:
+1st argument: Version in RubyGems format. Defaults to current lib/cypress_on_rails/version.rb.
+2nd argument: Dry run when 'true'.
+")
+task :sync_github_release, %i[gem_version dry_run] do |_t, args|
+  gem_root = File.expand_path("..", __dir__)
+  version = args[:gem_version].to_s.strip
+  version = current_gem_version(gem_root) if version.empty?
+  validate_requested_version_input!(version)
+
+  dry_run = release_truthy?(args[:dry_run])
+  verify_gh_auth(gem_root: gem_root) unless dry_run
+  sync_github_release_after_publish(gem_root: gem_root, gem_version: normalize_release_version_string(version), dry_run: dry_run)
+end

--- a/rakelib/update_changelog.rake
+++ b/rakelib/update_changelog.rake
@@ -205,6 +205,18 @@ def normalize_heading_key(line)
   "#{heading_level} #{heading_text}".strip
 end
 
+def warning_changelog_heading?(line)
+  line.to_s.match?(/\A###+\s+WARNING:/i)
+end
+
+def prefer_warning_heading(existing_block, incoming_heading)
+  existing_heading = existing_block.lines.first&.rstrip || ""
+  return existing_block if warning_changelog_heading?(existing_heading)
+  return existing_block unless warning_changelog_heading?(incoming_heading)
+
+  existing_block.sub(/\A[^\n]*/, incoming_heading)
+end
+
 def deduplicate_block_entries(block)
   lines = block.lines
   first_line = lines.first&.rstrip || ""
@@ -260,6 +272,7 @@ def consolidate_changelog_blocks(blocks)
       heading_key = normalize_heading_key(heading_match[1])
       if heading_indices.key?(heading_key)
         idx = heading_indices[heading_key]
+        consolidated[idx] = prefer_warning_heading(consolidated[idx], first_line)
         content_after_heading = cleaned.lines.drop(1).join.gsub(/\A\n+/, "").rstrip
         consolidated[idx] = "#{consolidated[idx].rstrip}\n#{content_after_heading}" unless content_after_heading.empty?
       else
@@ -274,6 +287,13 @@ def consolidate_changelog_blocks(blocks)
   consolidated.map { |block| deduplicate_block_entries(block) }
 end
 
+def normalized_changelog_section_version(section)
+  version = section[:version].to_s
+  return nil if version.casecmp("Unreleased").zero?
+
+  normalize_version_string(version)
+end
+
 def collapse_prerelease_sections(changelog, base_version, channel)
   parsed = parse_changelog_sections(changelog)
   sections = parsed[:sections]
@@ -281,7 +301,10 @@ def collapse_prerelease_sections(changelog, base_version, channel)
   return changelog unless unreleased_section
 
   target_regex = /\A#{Regexp.escape(base_version)}\.#{channel}\.\d+\z/i
-  matching_sections = sections.select { |section| normalize_version_string(section[:version]).match?(target_regex) }
+  matching_sections = sections.select do |section|
+    normalized_version = normalized_changelog_section_version(section)
+    normalized_version&.match?(target_regex)
+  end
   return changelog if matching_sections.empty?
 
   all_blocks = changelog_section_blocks(unreleased_section[:body]) +
@@ -289,7 +312,10 @@ def collapse_prerelease_sections(changelog, base_version, channel)
   consolidated = consolidate_changelog_blocks(all_blocks)
   merged_body = consolidated.join("\n\n").strip
 
-  sections.reject! { |section| normalize_version_string(section[:version]).match?(target_regex) }
+  sections.reject! do |section|
+    normalized_version = normalized_changelog_section_version(section)
+    normalized_version&.match?(target_regex)
+  end
   unreleased_section[:body] = merged_body.empty? ? "\n" : "\n\n#{merged_body}\n"
 
   render_changelog_sections(parsed[:prefix], sections)
@@ -440,7 +466,7 @@ task :update_changelog, %i[mode_or_tag] do |_, args|
   if auto_mode
     fetch_git_tags!(gem_root)
     prepared_changelog = auto_mode == "release" ? prepare_changelog_for_auto_version(changelog, gem_root) : changelog
-    changelog_version = compute_auto_version(prepared_changelog, auto_mode, gem_root, changelog_for_bump: changelog)
+    changelog_version = compute_auto_version(prepared_changelog, auto_mode, gem_root)
     changelog = prepared_changelog
     tag_date = Date.today.strftime("%Y-%m-%d")
     puts "Auto-computed #{auto_mode} version: #{changelog_version}"

--- a/rakelib/update_changelog.rake
+++ b/rakelib/update_changelog.rake
@@ -369,6 +369,11 @@ end
 def compute_auto_version(changelog, mode, gem_root, changelog_for_bump: nil)
   changelog_for_bump ||= changelog
 
+  if mode == "release"
+    active_base_version = active_prerelease_base_version(gem_root, changelog)
+    return active_base_version if active_base_version
+  end
+
   active_version = next_active_prerelease_version(changelog, mode, gem_root)
   return active_version if active_version
 

--- a/rakelib/update_changelog.rake
+++ b/rakelib/update_changelog.rake
@@ -1,63 +1,477 @@
 # frozen_string_literal: true
 
+require "date"
 require "English"
+require "open3"
+require "rubygems/version"
 
-desc "Updates CHANGELOG.md inserting headers for the new version.
+CHANGELOG_COMPARE_PREFIX = "https://github.com/shakacode/cypress-playwright-on-rails/compare" unless defined?(CHANGELOG_COMPARE_PREFIX)
+CHANGELOG_BASE_BRANCH = "master" unless defined?(CHANGELOG_BASE_BRANCH)
 
-Argument: Git tag. Defaults to the latest tag."
+def gem_root_for_changelog
+  File.expand_path("..", __dir__)
+end
 
-task :update_changelog, %i[tag] do |_, args|
-  tag = args[:tag] || `git describe --tags --abbrev=0`.strip
+def prerelease_version?(version)
+  version.to_s.match?(/\.(beta|rc)\./i)
+end
 
-  # Remove 'v' prefix if present (e.g., v1.18.0 -> 1.18.0)
-  version = tag.start_with?('v') ? tag[1..-1] : tag
-  anchor = "[#{version}]"
+def normalize_version_string(version_or_tag)
+  version = version_or_tag.to_s.strip
+  version = version.delete_prefix("v")
+  version = version.sub(/-(beta|rc)\./i, '.\1.')
 
-  changelog = File.read("CHANGELOG.md")
+  unless version.match?(/\A\d+\.\d+\.\d+(\.(beta|rc)\.\d+)?\z/i)
+    abort "Failed to parse version from #{version_or_tag.inspect}. Expected format like 1.21.0 or 1.21.0.rc.0."
+  end
 
-  if changelog.include?(anchor)
-    puts "Tag #{version} is already documented in CHANGELOG.md, update manually if needed"
+  version.downcase
+end
+
+def parse_release_tag_to_version(tag)
+  version_pattern = /\d+\.\d+\.\d+(?:\.(?:beta|rc)\.\d+)?|\d+\.\d+\.\d+-(?:beta|rc)\.\d+/
+  tag_match = tag.to_s.strip.match(/\Av(?<version>#{version_pattern})\z/i)
+  return nil unless tag_match
+
+  normalize_version_string(tag_match[:version])
+rescue SystemExit
+  nil
+end
+
+def fetch_git_tags!(gem_root)
+  remotes_output, remotes_status = Open3.capture2e("git", "-C", gem_root, "remote")
+  abort "Failed to list git remotes.\n#{remotes_output}" unless remotes_status.success?
+
+  remote_names = remotes_output.lines.map(&:strip).reject(&:empty?)
+  return if remote_names.empty?
+
+  remote_name = remote_names.include?("origin") ? "origin" : remote_names.first
+  fetch_output, fetch_status = Open3.capture2e("git", "-C", gem_root, "fetch", remote_name, "--tags", "--quiet")
+  abort "Failed to fetch git tags from #{remote_name}.\n#{fetch_output}" unless fetch_status.success?
+end
+
+def tag_versions(gem_root)
+  tags_output, status = Open3.capture2e("git", "-C", gem_root, "tag", "-l", "v*")
+  abort "Failed to list git tags.\n#{tags_output}" unless status.success?
+
+  tags_output.lines.map(&:strip).filter_map { |tag| parse_release_tag_to_version(tag) }.uniq
+end
+
+def stable_tag_versions(gem_root)
+  tag_versions(gem_root).reject { |version| prerelease_version?(version) }
+end
+
+def latest_stable_tag_version(gem_root)
+  versions = stable_tag_versions(gem_root)
+  abort "Failed to compute latest stable tag: no stable v* tags found." if versions.empty?
+
+  versions.max_by { |version| Gem::Version.new(version) }
+end
+
+def extract_unreleased_section(changelog)
+  lines = changelog.lines
+  start_index = lines.index { |line| line.start_with?("## [Unreleased]") }
+  abort "Failed to find '## [Unreleased]' in CHANGELOG.md" unless start_index
+
+  end_index = ((start_index + 1)...lines.length).find { |idx| lines[idx].start_with?("## [") || lines[idx].start_with?("---") } || lines.length
+  lines[start_index...end_index].join
+end
+
+def inferred_bump_type_from_unreleased(changelog)
+  section = extract_unreleased_section(changelog)
+  return :major if section.match?(/^###\s+(?:WARNING:\s*)?Breaking(?:\s+Changes?)?\b/i)
+  return :minor if section.match?(/^###\s+(Added|New\s+Features?|Features?|Enhancements?)\b/i)
+  return :patch if section.match?(/^###\s+(Fixed|Fixes|Bug\s+Fixes?|Security|Improved|Changed|Deprecated|Removed)\b/i)
+
+  :patch
+end
+
+def bump_stable_version(version, bump_type)
+  match = version.match(/\A(\d+)\.(\d+)\.(\d+)\z/)
+  abort "Failed to bump version: stable version #{version.inspect} is invalid." unless match
+
+  major = match[1].to_i
+  minor = match[2].to_i
+  patch = match[3].to_i
+
+  case bump_type
+  when :major
+    "#{major + 1}.0.0"
+  when :minor
+    "#{major}.#{minor + 1}.0"
+  else
+    "#{major}.#{minor}.#{patch + 1}"
+  end
+end
+
+def prerelease_indices_from_tags(gem_root, base_version, channel)
+  tags_output, status = Open3.capture2e("git", "-C", gem_root, "tag", "-l", "v#{base_version}*")
+  abort "Failed to list prerelease tags.\n#{tags_output}" unless status.success?
+
+  tags_output.lines.map(&:strip).filter_map do |tag|
+    normalized_version = parse_release_tag_to_version(tag)
+    match = normalized_version&.match(/\A#{Regexp.escape(base_version)}\.#{channel}\.(\d+)\z/i)
+    match&.captures&.first&.to_i
+  end
+end
+
+def parse_changelog_sections(changelog)
+  lines = changelog.lines
+  headers = []
+  lines.each_with_index do |line, index|
+    match = line.match(/^## \[([^\]]+)\].*$/)
+    headers << { index: index, version: match[1], header: line } if match
+  end
+
+  return { prefix: changelog, sections: [] } if headers.empty?
+
+  prefix = lines[0...headers.first[:index]].join
+  sections = headers.each_with_index.map do |header, section_index|
+    section_end = if section_index + 1 < headers.length
+                    headers[section_index + 1][:index]
+                  else
+                    lines.length
+                  end
+
+    {
+      version: header[:version],
+      header: header[:header],
+      body: lines[(header[:index] + 1)...section_end].join
+    }
+  end
+
+  { prefix: prefix, sections: sections }
+end
+
+def render_changelog_sections(prefix, sections)
+  "#{prefix}#{sections.map { |section| "#{section[:header]}#{section[:body]}" }.join}"
+end
+
+def changelog_versions(changelog)
+  parse_changelog_sections(changelog)[:sections]
+    .map { |section| section[:version] }
+    .reject { |version| version.casecmp("Unreleased").zero? }
+    .map { |version| normalize_version_string(version) }
+end
+
+def prerelease_base_version(version)
+  version.to_s.sub(/\.(beta|rc)\.\d+\z/i, "")
+end
+
+def active_prerelease_base_version(gem_root, changelog)
+  latest_stable = latest_stable_tag_version(gem_root)
+  prerelease_bases = (tag_versions(gem_root) + changelog_versions(changelog))
+                     .uniq
+                     .select { |version| prerelease_version?(version) }
+                     .map { |version| prerelease_base_version(version) }
+                     .select { |base_version| Gem::Version.new(base_version) > Gem::Version.new(latest_stable) }
+                     .uniq
+
+  prerelease_bases.max_by { |base_version| Gem::Version.new(base_version) }
+end
+
+def changelog_section_blocks(section_body)
+  block_lines = []
+  blocks = []
+
+  section_body.lines.each do |line|
+    normalized_line = line.rstrip
+    if normalized_line.match?(/^###+\s+/) && !block_lines.empty?
+      blocks << normalize_changelog_block(block_lines)
+      block_lines = [normalized_line]
+    else
+      block_lines << normalized_line
+    end
+  end
+
+  blocks << normalize_changelog_block(block_lines) unless block_lines.empty?
+  blocks.reject(&:empty?)
+end
+
+def normalize_changelog_block(lines)
+  normalized_lines = lines.map(&:rstrip)
+  normalized_lines.shift while normalized_lines.first == ""
+  normalized_lines.pop while normalized_lines.last == ""
+  normalized_lines.join("\n")
+end
+
+def normalize_heading_key(line)
+  normalized = line.to_s.strip
+  heading_level = normalized[/\A(#+)/, 1] || ""
+  heading_text = normalized.sub(/\A#+\s+/, "")
+                           .gsub(/\A(?:WARNING:)\s*/i, "")
+                           .downcase
+                           .gsub(/\s+/, " ")
+  "#{heading_level} #{heading_text}".strip
+end
+
+def deduplicate_block_entries(block)
+  lines = block.lines
+  first_line = lines.first&.rstrip || ""
+  return block unless first_line.match?(/\A###+\s+/)
+
+  heading = first_line
+  body_lines = lines.drop(1)
+  entries = []
+  current_entry = nil
+
+  body_lines.each do |line|
+    next if line.strip.empty? && entries.empty? && current_entry.nil?
+
+    if line.start_with?("- ") || line.start_with?("* ")
+      entries << current_entry if current_entry
+      current_entry = +line
+    elsif current_entry
+      current_entry << line
+    else
+      entries << line
+    end
+  end
+  entries << current_entry if current_entry
+
+  seen_texts = {}
+  unique_entries = entries.select do |entry|
+    key = entry.to_s.strip
+    if key.empty?
+      true
+    elsif seen_texts.key?(key)
+      false
+    else
+      seen_texts[key] = true
+      true
+    end
+  end
+
+  "#{heading}\n#{unique_entries.join}"
+end
+
+def consolidate_changelog_blocks(blocks)
+  consolidated = []
+  heading_indices = {}
+
+  blocks.each do |block|
+    cleaned = block.strip
+    next if cleaned.empty?
+
+    first_line = cleaned.lines.first&.rstrip || ""
+    heading_match = first_line.match(/\A(###+\s+.+)/)
+
+    if heading_match
+      heading_key = normalize_heading_key(heading_match[1])
+      if heading_indices.key?(heading_key)
+        idx = heading_indices[heading_key]
+        content_after_heading = cleaned.lines.drop(1).join.gsub(/\A\n+/, "").rstrip
+        consolidated[idx] = "#{consolidated[idx].rstrip}\n#{content_after_heading}" unless content_after_heading.empty?
+      else
+        heading_indices[heading_key] = consolidated.length
+        consolidated << cleaned
+      end
+    else
+      consolidated << cleaned
+    end
+  end
+
+  consolidated.map { |block| deduplicate_block_entries(block) }
+end
+
+def collapse_prerelease_sections(changelog, base_version, channel)
+  parsed = parse_changelog_sections(changelog)
+  sections = parsed[:sections]
+  unreleased_section = sections.find { |section| section[:version] == "Unreleased" }
+  return changelog unless unreleased_section
+
+  target_regex = /\A#{Regexp.escape(base_version)}\.#{channel}\.\d+\z/i
+  matching_sections = sections.select { |section| normalize_version_string(section[:version]).match?(target_regex) }
+  return changelog if matching_sections.empty?
+
+  all_blocks = changelog_section_blocks(unreleased_section[:body]) +
+               matching_sections.flat_map { |section| changelog_section_blocks(section[:body]) }
+  consolidated = consolidate_changelog_blocks(all_blocks)
+  merged_body = consolidated.join("\n\n").strip
+
+  sections.reject! { |section| normalize_version_string(section[:version]).match?(target_regex) }
+  unreleased_section[:body] = merged_body.empty? ? "\n" : "\n\n#{merged_body}\n"
+
+  render_changelog_sections(parsed[:prefix], sections)
+end
+
+def collapse_prerelease_series(changelog, base_version)
+  %w[beta rc].reduce(changelog) do |current_changelog, channel|
+    collapse_prerelease_sections(current_changelog, base_version, channel)
+  end
+end
+
+def cleanup_collapsed_prerelease_links(changelog, base_version)
+  compare_prefix = Regexp.escape("#{CHANGELOG_COMPARE_PREFIX}/")
+  prerelease_pattern = /#{Regexp.escape(base_version)}\.(?:beta|rc)\.\d+/i
+  stable_from = nil
+
+  changelog.scan(/^\[#{prerelease_pattern}\]:\s*#{compare_prefix}(\S+)\.\.\./i) do |from_version,|
+    stable_from = from_version unless from_version.delete_prefix("v").match?(prerelease_pattern)
+  end
+
+  if stable_from
+    changelog = changelog.sub(
+      /^(\[unreleased\]:\s*#{compare_prefix})\S+(\.\.\.#{CHANGELOG_BASE_BRANCH})/i,
+      "\\1#{stable_from}\\2"
+    )
+  end
+
+  changelog.gsub(/^\[#{prerelease_pattern}\]:.*\n/i, "")
+end
+
+def prepare_changelog_for_auto_version(changelog, gem_root)
+  active_base_version = active_prerelease_base_version(gem_root, changelog)
+  return changelog unless active_base_version
+
+  changelog = collapse_prerelease_series(changelog, active_base_version)
+  cleanup_collapsed_prerelease_links(changelog, active_base_version)
+end
+
+def next_active_prerelease_version(changelog, mode, gem_root)
+  return nil unless %w[rc beta].include?(mode)
+
+  active_base = active_prerelease_base_version(gem_root, changelog)
+  return nil unless active_base
+
+  indices = prerelease_indices_from_tags(gem_root, active_base, mode)
+  next_index = indices.empty? ? 0 : indices.max + 1
+  "#{active_base}.#{mode}.#{next_index}"
+end
+
+def compute_auto_version(changelog, mode, gem_root, changelog_for_bump: nil)
+  changelog_for_bump ||= changelog
+
+  active_version = next_active_prerelease_version(changelog, mode, gem_root)
+  return active_version if active_version
+
+  bump_type = inferred_bump_type_from_unreleased(changelog_for_bump)
+  latest_stable = latest_stable_tag_version(gem_root)
+  base_version = bump_stable_version(latest_stable, bump_type)
+
+  return base_version if mode == "release"
+
+  indices = prerelease_indices_from_tags(gem_root, base_version, mode)
+  next_index = indices.empty? ? 0 : indices.max + 1
+  "#{base_version}.#{mode}.#{next_index}"
+end
+
+def fetch_git_tag_date(gem_root, git_tag)
+  output, status = Open3.capture2e("git", "-C", gem_root, "show", "-s", "--format=%cs", git_tag)
+  return nil unless status.success?
+
+  output.split("\n").last&.strip
+end
+
+def version_header_versions(changelog)
+  changelog.scan(/^## \[([^\]]+)\]/).flatten
+           .reject { |version| version.casecmp("Unreleased").zero? }
+           .map { |version| normalize_version_string(version) }
+end
+
+def first_reference_link_version(changelog)
+  match = changelog.match(/^\[(\d+\.\d+\.\d+(?:\.(?:beta|rc)\.\d+)?)\]:\s*#{Regexp.escape(CHANGELOG_COMPARE_PREFIX)}\/\S+\.\.\.v\1/m)
+  match && normalize_version_string(match[1])
+end
+
+def ensure_previous_version_link!(changelog, previous_version)
+  return unless previous_version
+  return if changelog.match?(/^\[#{Regexp.escape(previous_version)}\]:/i)
+
+  previous_previous_version = first_reference_link_version(changelog)
+  return unless previous_previous_version
+
+  link = "[#{previous_version}]: #{CHANGELOG_COMPARE_PREFIX}/v#{previous_previous_version}...v#{previous_version}\n"
+  if changelog.include?("<!-- Version diff reference list -->")
+    changelog.sub!("<!-- Version diff reference list -->\n", "<!-- Version diff reference list -->\n#{link}")
+  else
+    changelog << "\n<!-- Version diff reference list -->\n#{link}"
+  end
+end
+
+def update_changelog_links(changelog, version, anchor)
+  existing_unreleased = changelog.match(
+    /^(?<prefix>\[unreleased\]:\s*#{Regexp.escape(CHANGELOG_COMPARE_PREFIX)}\/)(?<prev_version>\S+)(\.\.\.)(?<branch>#{CHANGELOG_BASE_BRANCH}|main)$/i
+  )
+
+  if existing_unreleased
+    previous_version = existing_unreleased[:prev_version]
+    replacement = "#{existing_unreleased[:prefix]}v#{version}...#{existing_unreleased[:branch]}\n" \
+                  "#{anchor}: #{CHANGELOG_COMPARE_PREFIX}/#{previous_version}...v#{version}"
+    changelog.sub!(existing_unreleased[0], replacement)
+    return
+  end
+
+  previous_version = version_header_versions(changelog).find { |candidate| candidate != version }
+  ensure_previous_version_link!(changelog, previous_version)
+
+  unreleased_link = "[unreleased]: #{CHANGELOG_COMPARE_PREFIX}/v#{version}...#{CHANGELOG_BASE_BRANCH}\n"
+  version_link = previous_version ? "#{anchor}: #{CHANGELOG_COMPARE_PREFIX}/v#{previous_version}...v#{version}\n" : ""
+  insertion = "#{unreleased_link}#{version_link}"
+
+  if changelog.include?("<!-- Version diff reference list -->")
+    changelog.sub!("<!-- Version diff reference list -->\n", "<!-- Version diff reference list -->\n#{insertion}")
+  else
+    changelog << "\n<!-- Version diff reference list -->\n#{insertion}"
+  end
+end
+
+def insert_version_header(changelog, anchor, tag_date)
+  !!changelog.sub!("## [Unreleased]", "## [Unreleased]\n\n## #{anchor} - #{tag_date}")
+end
+
+desc "Updates CHANGELOG.md by inserting a version header and compare links.
+Argument: Mode (`release`, `rc`, `beta`) or explicit git tag/version.
+
+Modes:
+  - release: auto-compute next stable version and collapse prior RC/beta sections
+  - rc: auto-compute next RC version; prior prerelease sections are left in place
+  - beta: auto-compute next beta version
+
+No argument: use latest git tag.
+For full entry analysis, run /update-changelog before this rake task."
+task :update_changelog, %i[mode_or_tag] do |_, args|
+  gem_root = gem_root_for_changelog
+  changelog_path = File.join(gem_root, "CHANGELOG.md")
+  changelog = File.read(changelog_path)
+  input = args[:mode_or_tag].to_s.strip
+  auto_mode = %w[release rc beta].find { |mode| mode == input.downcase }
+
+  if auto_mode
+    fetch_git_tags!(gem_root)
+    prepared_changelog = auto_mode == "release" ? prepare_changelog_for_auto_version(changelog, gem_root) : changelog
+    changelog_version = compute_auto_version(prepared_changelog, auto_mode, gem_root, changelog_for_bump: changelog)
+    changelog = prepared_changelog
+    tag_date = Date.today.strftime("%Y-%m-%d")
+    puts "Auto-computed #{auto_mode} version: #{changelog_version}"
+  else
+    git_tag = if input.empty?
+                git_output, git_status = Open3.capture2e("git", "-C", gem_root, "describe", "--tags", "--abbrev=0")
+                abort "Failed to get latest git tag.\n#{git_output}" unless git_status.success?
+
+                git_output.strip
+              else
+                input
+              end
+
+    changelog_version = normalize_version_string(git_tag)
+    tag_candidates = [git_tag, git_tag.start_with?("v") ? git_tag : "v#{git_tag}", "v#{changelog_version}"].uniq
+    tag_date = tag_candidates.filter_map { |candidate| fetch_git_tag_date(gem_root, candidate) }.first ||
+               Date.today.strftime("%Y-%m-%d")
+  end
+
+  anchor = "[#{changelog_version}]"
+  header = "## #{anchor}"
+  if changelog.include?(header)
+    puts "Version #{changelog_version} is already documented in CHANGELOG.md"
     next
   end
 
-  tag_date_output = `git show -s --format=%cs #{tag} 2>&1`
-  if $CHILD_STATUS.success?
-    tag_date = tag_date_output.split("\n").last.strip
-  else
-    abort("Failed to find tag #{tag}")
-  end
+  abort "Failed to insert version header: could not find '## [Unreleased]' in CHANGELOG.md" unless insert_version_header(changelog, anchor, tag_date)
 
-  # After "## [Unreleased]", insert new version header
-  unreleased_section = "## [Unreleased]"
-  new_version_header = "\n\n## #{anchor} - #{tag_date}"
+  update_changelog_links(changelog, changelog_version, anchor)
 
-  if changelog.include?(unreleased_section)
-    changelog.sub!(unreleased_section, "#{unreleased_section}#{new_version_header}")
-  else
-    abort("Could not find '## [Unreleased]' section in CHANGELOG.md")
-  end
-
-  # Find and update version comparison links at the bottom
-  # Pattern: [1.18.0]: https://github.com/shakacode/cypress-playwright-on-rails/compare/v1.17.0...v1.18.0
-  compare_link_prefix = "https://github.com/shakacode/cypress-playwright-on-rails/compare"
-
-  # Find the last version link to determine the previous version
-  last_version_match = changelog.match(/\[(\d+\.\d+\.\d+(?:\.\w+)?)\]:.*?compare\/v(\d+\.\d+\.\d+(?:\.\w+)?)\.\.\.v(\d+\.\d+\.\d+(?:\.\w+)?)/)
-
-  if last_version_match
-    last_version = last_version_match[1]
-    # Add new version link at the top of the version list
-    new_link = "#{anchor}: #{compare_link_prefix}/v#{last_version}...v#{version}"
-    # Insert after the "<!-- Version diff reference list -->" comment
-    changelog.sub!("<!-- Version diff reference list -->", "<!-- Version diff reference list -->\n#{new_link}")
-  else
-    puts "Warning: Could not find version comparison links. You may need to add the link manually."
-  end
-
-  File.write("CHANGELOG.md", changelog)
-  puts "Updated CHANGELOG.md with an entry for #{version}"
-  puts "\nNext steps:"
-  puts "1. Edit CHANGELOG.md to add release notes under the [#{version}] section"
-  puts "2. Move content from [Unreleased] to [#{version}] if applicable"
-  puts "3. Review and commit the changes"
+  File.write(changelog_path, changelog)
+  puts "Updated CHANGELOG.md with version header for #{changelog_version}"
+  puts "NOTE: You still need to verify changelog entries before releasing."
 end

--- a/rakelib/update_changelog.rake
+++ b/rakelib/update_changelog.rake
@@ -80,6 +80,7 @@ end
 def inferred_bump_type_from_unreleased(changelog)
   section = extract_unreleased_section(changelog)
   return :major if section.match?(/^###\s+(?:WARNING:\s*)?Breaking(?:\s+Changes?)?\b/i)
+  return :major if section.match?(/^\s*[-*]\s+(?:\*\*)?BREAKING\b/i)
   return :minor if section.match?(/^###\s+(Added|New\s+Features?|Features?|Enhancements?)\b/i)
   return :patch if section.match?(/^###\s+(Fixed|Fixes|Bug\s+Fixes?|Security|Improved|Changed|Deprecated|Removed)\b/i)
 

--- a/rakelib/update_changelog.rake
+++ b/rakelib/update_changelog.rake
@@ -177,6 +177,8 @@ def changelog_section_blocks(section_body)
 
   section_body.lines.each do |line|
     normalized_line = line.rstrip
+    next if normalized_line.match?(/\A---+\z/)
+
     if normalized_line.match?(/^###+\s+/) && !block_lines.empty?
       blocks << normalize_changelog_block(block_lines)
       block_lines = [normalized_line]

--- a/spec/cypress_on_rails/release_rake_spec.rb
+++ b/spec/cypress_on_rails/release_rake_spec.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fileutils"
+require "open3"
+require "rake"
+require "stringio"
+require "tmpdir"
+
+RSpec.describe "release rake helpers" do
+  before(:all) do
+    load File.expand_path("../../rakelib/release.rake", __dir__)
+  end
+
+  def capture_stdout
+    original_stdout = $stdout
+    output = StringIO.new
+    $stdout = output
+    yield
+    output.string
+  ensure
+    $stdout = original_stdout
+  end
+
+  describe "#parse_release_tag_to_gem_version" do
+    it "parses stable and prerelease tags" do
+      expect(parse_release_tag_to_gem_version("v1.21.0")).to eq("1.21.0")
+      expect(parse_release_tag_to_gem_version("v1.21.0.rc.1")).to eq("1.21.0.rc.1")
+      expect(parse_release_tag_to_gem_version("v1.21.0-rc.1")).to eq("1.21.0.rc.1")
+    end
+  end
+
+  describe "#compute_target_gem_version" do
+    it "computes semver keyword bumps" do
+      expect(compute_target_gem_version(current_gem_version: "1.20.3", version_input: "patch")).to eq("1.20.4")
+      expect(compute_target_gem_version(current_gem_version: "1.20.3", version_input: "minor")).to eq("1.21.0")
+      expect(compute_target_gem_version(current_gem_version: "1.20.3", version_input: "major")).to eq("2.0.0")
+    end
+
+    it "promotes prereleases to stable with patch" do
+      expect(compute_target_gem_version(current_gem_version: "1.21.0.rc.0", version_input: "patch")).to eq("1.21.0")
+    end
+
+    it "passes explicit versions through unchanged" do
+      expect(compute_target_gem_version(current_gem_version: "1.20.0", version_input: "1.21.0.rc.0"))
+        .to eq("1.21.0.rc.0")
+    end
+  end
+
+  describe "#extract_latest_changelog_version" do
+    it "reads the first versioned changelog header after Unreleased" do
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, "CHANGELOG.md"), <<~CHANGELOG)
+          # Changelog
+
+          ## [Unreleased]
+
+          ## [1.21.0.rc.0] - 2026-07-04
+          ### Fixed
+          * Fix
+        CHANGELOG
+
+        expect(extract_latest_changelog_version(gem_root: dir)).to eq("1.21.0.rc.0")
+      end
+    end
+  end
+
+  describe "#resolve_version_input" do
+    it "uses the changelog version when it is newer than the current gem version" do
+      allow(self).to receive(:extract_latest_changelog_version).with(gem_root: "/repo").and_return("1.21.0.rc.0")
+      allow(self).to receive(:current_gem_version).with("/repo").and_return("1.20.0")
+
+      result = nil
+      capture_stdout { result = resolve_version_input("", "/repo") }
+
+      expect(result).to eq("1.21.0.rc.0")
+    end
+
+    it "uses the current changelog version when it matches the gem version and is untagged" do
+      allow(self).to receive(:extract_latest_changelog_version).with(gem_root: "/repo").and_return("1.21.0.rc.0")
+      allow(self).to receive(:current_gem_version).with("/repo").and_return("1.21.0.rc.0")
+      allow(self).to receive(:version_tagged?).with("/repo", "1.21.0.rc.0").and_return(false)
+
+      result = nil
+      capture_stdout { result = resolve_version_input("", "/repo") }
+
+      expect(result).to eq("1.21.0.rc.0")
+    end
+
+    it "falls back to patch when the matching changelog version is already tagged" do
+      allow(self).to receive(:extract_latest_changelog_version).with(gem_root: "/repo").and_return("1.20.0")
+      allow(self).to receive(:current_gem_version).with("/repo").and_return("1.20.0")
+      allow(self).to receive(:version_tagged?).with("/repo", "1.20.0").and_return(true)
+
+      result = nil
+      capture_stdout { result = resolve_version_input("", "/repo") }
+
+      expect(result).to eq("patch")
+    end
+  end
+
+  describe "#expected_bump_type_from_changelog_section" do
+    it "infers bump shape from changelog headings" do
+      expect(expected_bump_type_from_changelog_section("### Breaking Changes\n* Break")).to eq(:major)
+      expect(expected_bump_type_from_changelog_section("### Added\n* Feature")).to eq(:minor)
+      expect(expected_bump_type_from_changelog_section("### Fixed\n* Fix")).to eq(:patch)
+    end
+  end
+
+  describe "#extract_changelog_section" do
+    it "extracts body text for the requested version without including adjacent sections" do
+      Dir.mktmpdir do |dir|
+        changelog_path = File.join(dir, "CHANGELOG.md")
+        File.write(changelog_path, <<~CHANGELOG)
+          # Changelog
+
+          ## [Unreleased]
+
+          ## [1.21.0] - 2026-07-04
+          ### Fixed
+          * New fix
+
+          ## [1.20.0] - 2025-10-21
+          ### Changed
+          * Old change
+        CHANGELOG
+
+        section = extract_changelog_section(changelog_path: changelog_path, version: "1.21.0")
+
+        expect(section).to include("* New fix")
+        expect(section).not_to include("## [1.21.0]")
+        expect(section).not_to include("* Old change")
+      end
+    end
+
+    it "returns nil when the section has no release notes" do
+      Dir.mktmpdir do |dir|
+        changelog_path = File.join(dir, "CHANGELOG.md")
+        File.write(changelog_path, <<~CHANGELOG)
+          ## [Unreleased]
+
+          ## [1.21.0] - 2026-07-04
+
+          ## [1.20.0] - 2025-10-21
+          ### Fixed
+          * Old fix
+        CHANGELOG
+
+        expect(extract_changelog_section(changelog_path: changelog_path, version: "1.21.0")).to be_nil
+      end
+    end
+  end
+
+  describe "#github_repo_slug" do
+    def stub_origin_url(url, success: true)
+      status = instance_double(Process::Status, success?: success)
+      allow(Open3).to receive(:capture2e)
+        .with("git", "-C", "/repo", "remote", "get-url", "origin")
+        .and_return(["#{url}\n", status])
+    end
+
+    it "extracts slugs from common GitHub remote URL formats" do
+      {
+        "git@github.com:shakacode/cypress-playwright-on-rails.git" => "shakacode/cypress-playwright-on-rails",
+        "ssh://git@github.com/shakacode/cypress-playwright-on-rails.git" => "shakacode/cypress-playwright-on-rails",
+        "https://github.com/shakacode/cypress-playwright-on-rails.git" => "shakacode/cypress-playwright-on-rails",
+        "github.com/shakacode/cypress-playwright-on-rails" => "shakacode/cypress-playwright-on-rails"
+      }.each do |origin_url, expected_slug|
+        stub_origin_url(origin_url)
+
+        expect(github_repo_slug("/repo")).to eq(expected_slug)
+      end
+    end
+  end
+
+  describe "#with_release_checkout" do
+    before do
+      allow(Dir).to receive(:mktmpdir)
+        .with("cypress-on-rails-release-dry-run")
+        .and_yield("/tmp/cypress-on-rails-release")
+    end
+
+    it "preserves release failures when dry-run worktree cleanup also fails" do
+      allow(self).to receive(:sh_in_dir_for_release) do |_dir, command|
+        raise "cleanup failed" if command.include?("git worktree remove")
+      end
+
+      expect do
+        expect do
+          with_release_checkout(gem_root: "/repo", dry_run: true) { raise "release failed" }
+        end.to raise_error(RuntimeError, "release failed")
+      end.to output(/Failed to remove dry-run release worktree/).to_stderr
+    end
+  end
+end

--- a/spec/cypress_on_rails/release_rake_spec.rb
+++ b/spec/cypress_on_rails/release_rake_spec.rb
@@ -102,6 +102,39 @@ RSpec.describe "release rake helpers" do
       expect(bump_command).to include("--version 1.21.0")
       expect(events.index("git pull --rebase")).to be < events.index(bump_command)
     end
+
+    it "tags and publishes the current commit for an untagged retry" do
+      events = []
+
+      allow(self).to receive(:ensure_clean_worktree!)
+      allow(self).to receive(:verify_gh_auth)
+      allow(self).to receive(:with_release_checkout)
+        .with(gem_root: File.expand_path("../..", __dir__), dry_run: false)
+        .and_yield("/fresh")
+      allow(self).to receive(:extract_latest_changelog_version)
+        .with(gem_root: "/fresh")
+        .and_return("1.21.0")
+      allow(self).to receive(:current_gem_version)
+        .with("/fresh")
+        .and_return("1.21.0", "1.21.0", "1.21.0")
+      allow(self).to receive(:version_tagged?).with("/fresh", "1.21.0").and_return(false)
+      allow(self).to receive(:warn_changelog_missing)
+      allow(self).to receive(:validate_release_version_policy!)
+      allow(self).to receive(:sync_github_release_after_publish)
+      allow(self).to receive(:sh_in_dir_for_release) do |_dir, command|
+        events << command
+      end
+
+      result = nil
+      capture_stdout { result = perform_release(gem_version: "", dry_run: false) }
+
+      expect(result[:released_gem_version]).to eq("1.21.0")
+      expect(events.grep(/gem bump/)).to be_empty
+      expect(events.grep(/git commit/)).to be_empty
+      expect(events).to include("git tag v1.21.0")
+      expect(events).to include("git push && git push --tags")
+      expect(events).to include("gem release")
+    end
   end
 
   describe "#resolve_version_input" do
@@ -143,6 +176,10 @@ RSpec.describe "release rake helpers" do
       expect(expected_bump_type_from_changelog_section("### Breaking Changes\n* Break")).to eq(:major)
       expect(expected_bump_type_from_changelog_section("### Added\n* Feature")).to eq(:minor)
       expect(expected_bump_type_from_changelog_section("### Fixed\n* Fix")).to eq(:patch)
+    end
+
+    it "treats inline BREAKING entries as major changes" do
+      expect(expected_bump_type_from_changelog_section("### Fixed\n* **BREAKING: Generator folder structure**: Changed")).to eq(:major)
     end
   end
 
@@ -186,6 +223,13 @@ RSpec.describe "release rake helpers" do
         CHANGELOG
 
         expect(extract_changelog_section(changelog_path: changelog_path, version: "1.21.0")).to be_nil
+      end
+    end
+
+    it "returns nil when the changelog file is missing" do
+      Dir.mktmpdir do |dir|
+        expect(extract_changelog_section(changelog_path: File.join(dir, "CHANGELOG.md"), version: "1.21.0"))
+          .to be_nil
       end
     end
   end

--- a/spec/cypress_on_rails/release_rake_spec.rb
+++ b/spec/cypress_on_rails/release_rake_spec.rb
@@ -65,6 +65,45 @@ RSpec.describe "release rake helpers" do
     end
   end
 
+  describe "#release_staged_files" do
+    it "stages only tracked release metadata" do
+      expect(release_staged_files).to eq(["lib/cypress_on_rails/version.rb"])
+    end
+  end
+
+  describe "#perform_release" do
+    it "pulls the release checkout before resolving a blank version input" do
+      events = []
+
+      allow(self).to receive(:ensure_clean_worktree!)
+      allow(self).to receive(:verify_gh_auth)
+      allow(self).to receive(:with_release_checkout)
+        .with(gem_root: File.expand_path("../..", __dir__), dry_run: false)
+        .and_yield("/fresh")
+      allow(self).to receive(:extract_latest_changelog_version)
+        .with(gem_root: "/fresh")
+        .and_return("1.21.0")
+      allow(self).to receive(:current_gem_version)
+        .with("/fresh")
+        .and_return("1.20.0", "1.20.0", "1.21.0")
+      allow(self).to receive(:warn_changelog_missing)
+      allow(self).to receive(:validate_release_version_policy!)
+      allow(self).to receive(:sync_github_release_after_publish)
+      allow(self).to receive(:sh_in_dir_for_release) do |_dir, command|
+        events << command
+      end
+
+      result = nil
+      capture_stdout { result = perform_release(gem_version: "", dry_run: false) }
+      bump_command = events.find { |command| command.include?("gem bump") }
+
+      expect(result[:released_gem_version]).to eq("1.21.0")
+      expect(events).to include("git pull --rebase")
+      expect(bump_command).to include("--version 1.21.0")
+      expect(events.index("git pull --rebase")).to be < events.index(bump_command)
+    end
+  end
+
   describe "#resolve_version_input" do
     it "uses the changelog version when it is newer than the current gem version" do
       allow(self).to receive(:extract_latest_changelog_version).with(gem_root: "/repo").and_return("1.21.0.rc.0")

--- a/spec/cypress_on_rails/release_rake_spec.rb
+++ b/spec/cypress_on_rails/release_rake_spec.rb
@@ -183,6 +183,28 @@ RSpec.describe "release rake helpers" do
     end
   end
 
+  describe "#validate_release_version_policy!" do
+    it "allows stable promotion of an active prerelease even when notes look patch-only" do
+      allow(self).to receive(:tagged_release_gem_versions)
+        .with("/repo", fetch_tags: false)
+        .and_return(["1.20.0", "1.21.0.rc.0"])
+      allow(self).to receive(:extract_changelog_section)
+        .with(changelog_path: "/repo/CHANGELOG.md", version: "1.21.0")
+        .and_return("### Fixed\n* Stabilization fix")
+
+      expect do
+        capture_stdout do
+          validate_release_version_policy!(
+            gem_root: "/repo",
+            target_gem_version: "1.21.0",
+            allow_override: false,
+            fetch_tags: false
+          )
+        end
+      end.not_to raise_error
+    end
+  end
+
   describe "#extract_changelog_section" do
     it "extracts body text for the requested version without including adjacent sections" do
       Dir.mktmpdir do |dir|

--- a/spec/cypress_on_rails/update_changelog_rake_spec.rb
+++ b/spec/cypress_on_rails/update_changelog_rake_spec.rb
@@ -98,6 +98,26 @@ RSpec.describe "update_changelog rake helpers" do
         expect(compute_auto_version(prepared_changelog, "release", repo_dir)).to eq("1.21.0")
       end
     end
+
+    it "promotes an active prerelease base even when collapsed rc notes look patch-only" do
+      Dir.mktmpdir do |repo_dir|
+        init_git_repo!(repo_dir)
+        run_git!("tag", "v1.20.0", chdir: repo_dir)
+        run_git!("tag", "v1.21.0.rc.0", chdir: repo_dir)
+
+        changelog = <<~CHANGELOG
+          ## [Unreleased]
+
+          ## [1.21.0.rc.0] - 2026-07-04
+
+          ### Fixed
+          * Stabilization fix
+        CHANGELOG
+        prepared_changelog = prepare_changelog_for_auto_version(changelog, repo_dir)
+
+        expect(compute_auto_version(prepared_changelog, "release", repo_dir)).to eq("1.21.0")
+      end
+    end
   end
 
   describe "#collapse_prerelease_sections" do

--- a/spec/cypress_on_rails/update_changelog_rake_spec.rb
+++ b/spec/cypress_on_rails/update_changelog_rake_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "open3"
+require "rake"
+require "tmpdir"
+
+RSpec.describe "update_changelog rake helpers" do
+  before(:all) do
+    load File.expand_path("../../rakelib/update_changelog.rake", __dir__)
+  end
+
+  def run_git!(*args, chdir:)
+    output, status = Open3.capture2e("git", *args, chdir: chdir)
+    raise "git #{args.join(' ')} failed:\n#{output}" unless status.success?
+
+    output.strip
+  end
+
+  def init_git_repo!(repo_dir)
+    run_git!("init", chdir: repo_dir)
+    run_git!("config", "user.email", "test@example.com", chdir: repo_dir)
+    run_git!("config", "user.name", "Test User", chdir: repo_dir)
+    File.write(File.join(repo_dir, "README.md"), "test\n")
+    run_git!("add", "README.md", chdir: repo_dir)
+    run_git!("commit", "-m", "Initial commit", chdir: repo_dir)
+  end
+
+  describe "#normalize_version_string" do
+    it "normalizes stable and prerelease tags to RubyGems format" do
+      expect(normalize_version_string("v1.21.0")).to eq("1.21.0")
+      expect(normalize_version_string("1.21.0-rc.1")).to eq("1.21.0.rc.1")
+    end
+  end
+
+  describe "#inferred_bump_type_from_unreleased" do
+    it "infers major, minor, and patch from Unreleased headings" do
+      expect(inferred_bump_type_from_unreleased("## [Unreleased]\n### Breaking Changes\n* Break\n")).to eq(:major)
+      expect(inferred_bump_type_from_unreleased("## [Unreleased]\n### Added\n* Add\n")).to eq(:minor)
+      expect(inferred_bump_type_from_unreleased("## [Unreleased]\n### Fixed\n* Fix\n")).to eq(:patch)
+    end
+  end
+
+  describe "#compute_auto_version" do
+    it "computes the next rc version using git tags for the prerelease index" do
+      Dir.mktmpdir do |repo_dir|
+        init_git_repo!(repo_dir)
+        run_git!("tag", "v1.20.0", chdir: repo_dir)
+        run_git!("tag", "v1.21.0.rc.0", chdir: repo_dir)
+
+        changelog = <<~CHANGELOG
+          ## [Unreleased]
+          ### Added
+          * Feature
+        CHANGELOG
+
+        expect(compute_auto_version(changelog, "rc", repo_dir)).to eq("1.21.0.rc.1")
+      end
+    end
+
+    it "computes the next stable release from Unreleased headings" do
+      Dir.mktmpdir do |repo_dir|
+        init_git_repo!(repo_dir)
+        run_git!("tag", "v1.20.0", chdir: repo_dir)
+
+        changelog = <<~CHANGELOG
+          ## [Unreleased]
+          ### Fixed
+          * Fix
+        CHANGELOG
+
+        expect(compute_auto_version(changelog, "release", repo_dir)).to eq("1.20.1")
+      end
+    end
+  end
+
+  describe "#insert_version_header" do
+    it "inserts the version header after Unreleased" do
+      changelog = +"## [Unreleased]\n\n### Fixed\n* Fix\n"
+
+      expect(insert_version_header(changelog, "[1.21.0.rc.0]", "2026-07-04")).to eq(true)
+      expect(changelog).to include("## [Unreleased]\n\n## [1.21.0.rc.0] - 2026-07-04")
+    end
+  end
+
+  describe "#update_changelog_links" do
+    it "updates an existing unreleased compare link and adds the new version link" do
+      changelog = +"[unreleased]: https://github.com/shakacode/cypress-playwright-on-rails/compare/v1.20.0...master\n" \
+                   "[1.20.0]: https://github.com/shakacode/cypress-playwright-on-rails/compare/v1.19.0...v1.20.0\n"
+
+      update_changelog_links(changelog, "1.21.0", "[1.21.0]")
+
+      expect(changelog).to include("[unreleased]: https://github.com/shakacode/cypress-playwright-on-rails/compare/v1.21.0...master")
+      expect(changelog).to include("[1.21.0]: https://github.com/shakacode/cypress-playwright-on-rails/compare/v1.20.0...v1.21.0")
+    end
+
+    it "creates version links when the changelog has a reference list but no unreleased link" do
+      changelog = +"## [1.20.0] - 2025-10-21\n\n<!-- Version diff reference list -->\n" \
+                   "[1.19.0]: https://github.com/shakacode/cypress-playwright-on-rails/compare/v1.18.0...v1.19.0\n"
+
+      update_changelog_links(changelog, "1.21.0", "[1.21.0]")
+
+      expect(changelog).to include("[unreleased]: https://github.com/shakacode/cypress-playwright-on-rails/compare/v1.21.0...master")
+      expect(changelog).to include("[1.21.0]: https://github.com/shakacode/cypress-playwright-on-rails/compare/v1.20.0...v1.21.0")
+      expect(changelog).to include("[1.20.0]: https://github.com/shakacode/cypress-playwright-on-rails/compare/v1.19.0...v1.20.0")
+    end
+  end
+end

--- a/spec/cypress_on_rails/update_changelog_rake_spec.rb
+++ b/spec/cypress_on_rails/update_changelog_rake_spec.rb
@@ -72,6 +72,71 @@ RSpec.describe "update_changelog rake helpers" do
         expect(compute_auto_version(changelog, "release", repo_dir)).to eq("1.20.1")
       end
     end
+
+    it "infers the stable version from collapsed active rc notes" do
+      Dir.mktmpdir do |repo_dir|
+        init_git_repo!(repo_dir)
+        run_git!("tag", "v1.20.0", chdir: repo_dir)
+        run_git!("tag", "v1.21.0.rc.0", chdir: repo_dir)
+
+        changelog = <<~CHANGELOG
+          ## [Unreleased]
+
+          ## [1.21.0.rc.0] - 2026-07-04
+
+          ### Added
+          * Feature
+        CHANGELOG
+        prepared_changelog = prepare_changelog_for_auto_version(changelog, repo_dir)
+
+        expect(compute_auto_version(prepared_changelog, "release", repo_dir)).to eq("1.21.0")
+      end
+    end
+  end
+
+  describe "#collapse_prerelease_sections" do
+    it "skips Unreleased when matching prerelease sections" do
+      changelog = <<~CHANGELOG
+        ## [Unreleased]
+
+        ### Fixed
+        * Unreleased fix
+
+        ## [1.21.0.rc.0] - 2026-07-04
+
+        ### Added
+        * Feature
+      CHANGELOG
+
+      collapsed = collapse_prerelease_sections(changelog, "1.21.0", "rc")
+
+      expect(collapsed).to include("### Fixed")
+      expect(collapsed).to include("* Unreleased fix")
+      expect(collapsed).to include("### Added")
+      expect(collapsed).to include("* Feature")
+      expect(collapsed).not_to include("## [1.21.0.rc.0]")
+    end
+
+    it "preserves warning labels when merging breaking-change headings" do
+      changelog = <<~CHANGELOG
+        ## [Unreleased]
+
+        ### Breaking Changes
+        * Plain breaking note
+
+        ## [1.21.0.rc.0] - 2026-07-04
+
+        ### WARNING: Breaking Changes
+        * Warning breaking note
+      CHANGELOG
+
+      collapsed = collapse_prerelease_sections(changelog, "1.21.0", "rc")
+
+      expect(collapsed).to include("### WARNING: Breaking Changes")
+      expect(collapsed).to include("* Plain breaking note")
+      expect(collapsed).to include("* Warning breaking note")
+      expect(collapsed).not_to include("\n### Breaking Changes\n")
+    end
   end
 
   describe "#insert_version_header" do

--- a/spec/cypress_on_rails/update_changelog_rake_spec.rb
+++ b/spec/cypress_on_rails/update_changelog_rake_spec.rb
@@ -163,6 +163,33 @@ RSpec.describe "update_changelog rake helpers" do
       expect(collapsed).to include("* Warning breaking note")
       expect(collapsed).not_to include("\n### Breaking Changes\n")
     end
+
+    it "does not merge section separators into collapsed prerelease notes" do
+      changelog = <<~CHANGELOG
+        ## [Unreleased]
+
+        ---
+
+        ## [1.21.0.rc.0] - 2026-07-04
+
+        ### Fixed
+        * RC stabilization fix
+
+        ---
+
+        ## [1.20.0] - 2025-10-21
+
+        ### Fixed
+        * Previous fix
+      CHANGELOG
+
+      collapsed = collapse_prerelease_sections(changelog, "1.21.0", "rc")
+      unreleased_section = extract_unreleased_section(collapsed)
+
+      expect(unreleased_section).to include("### Fixed")
+      expect(unreleased_section).to include("* RC stabilization fix")
+      expect(unreleased_section).not_to include("---")
+    end
   end
 
   describe "#insert_version_header" do

--- a/spec/cypress_on_rails/update_changelog_rake_spec.rb
+++ b/spec/cypress_on_rails/update_changelog_rake_spec.rb
@@ -39,6 +39,12 @@ RSpec.describe "update_changelog rake helpers" do
       expect(inferred_bump_type_from_unreleased("## [Unreleased]\n### Added\n* Add\n")).to eq(:minor)
       expect(inferred_bump_type_from_unreleased("## [Unreleased]\n### Fixed\n* Fix\n")).to eq(:patch)
     end
+
+    it "treats inline BREAKING entries as major changes" do
+      changelog = "## [Unreleased]\n### Fixed\n* **BREAKING: Generator folder structure**: Changed\n"
+
+      expect(inferred_bump_type_from_unreleased(changelog)).to eq(:major)
+    end
   end
 
   describe "#compute_auto_version" do


### PR DESCRIPTION
## Summary

Ports the Shakapacker / React on Rails release shape into this RubyGems-only repo:

- `bundle exec rake update_changelog[release|rc|beta|VERSION]` can stamp version headers before release.
- `bundle exec rake release` now reads the newest stamped `CHANGELOG.md` version, falling back to a patch bump when no new version is stamped.
- Release dry-runs use a temporary git worktree so the checkout stays clean.
- Release validates version policy, bumps version/Gemfile.lock, tags, pushes, publishes the gem, and syncs the GitHub release from `CHANGELOG.md`.
- Adds `sync_github_release`, repo-local `/update-changelog` guidance, `.agents/agent-workflow.yml`, and focused rake helper specs.
- Updates release docs to put changelog-before-release as the default flow.

## Validation

- `bundle exec rspec spec/cypress_on_rails/release_rake_spec.rb spec/cypress_on_rails/update_changelog_rake_spec.rb`
- `bundle exec rake -T`
- `bundle exec rake`
- `git diff --check`
- `ruby -c rakelib/release.rake && ruby -c rakelib/update_changelog.rake`
- `bundle exec rake "release[,true]"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated changelog and release workflow supporting release, beta, and release-candidate flows.
  * Releases now include stricter version validation, safer dry-run handling, and automatic GitHub release syncing from the changelog; added a dedicated GitHub sync option.
* **Documentation**
  * Rewrote release guides into a shorter, checklist-based process using the changelog update command, merge, and `rake release`.
* **Tests**
  * Expanded/added test coverage for version parsing and resolution, changelog section and link updates, release note extraction, and dry-run cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->