### PR TITLE
[codex] Clarify sync GitHub release input

### DIFF
--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -600,6 +600,9 @@ task :sync_github_release, %i[gem_version dry_run] do |_t, args|
   gem_root = File.expand_path("..", __dir__)
   version = args[:gem_version].to_s.strip
   version = current_gem_version(gem_root) if version.empty?
+  if semver_keyword?(version)
+    abort "sync_github_release expects an explicit version like 1.21.0 or 1.21.0.rc.0; semver keywords are only supported by the release task."
+  end
   validate_requested_version_input!(version)
 
   dry_run = release_truthy?(args[:dry_run])

--- a/spec/cypress_on_rails/release_rake_spec.rb
+++ b/spec/cypress_on_rails/release_rake_spec.rb
@@ -205,6 +205,30 @@ RSpec.describe "release rake helpers" do
     end
   end
 
+  describe "sync_github_release task" do
+    it "rejects semver keywords with a task-specific error" do
+      task = Rake::Task["sync_github_release"]
+      task.reenable
+
+      expect do
+        task.invoke("patch", "true")
+      end.to raise_error(SystemExit, /sync_github_release expects an explicit version/)
+    end
+
+    it "defaults to the current gem version for dry runs" do
+      task = Rake::Task["sync_github_release"]
+      task.reenable
+      gem_root = File.expand_path("../..", __dir__)
+      expected_version = current_gem_version(gem_root)
+
+      output = capture_stdout do
+        task.invoke(nil, "true")
+      end
+
+      expect(output).to include("DRY RUN: Would create or update GitHub release v#{expected_version}")
+    end
+  end
+
   describe "#extract_changelog_section" do
     it "extracts body text for the requested version without including adjacent sections" do
       Dir.mktmpdir do |dir|


### PR DESCRIPTION
## Summary

Fixes #232.

- reject `sync_github_release[patch]` / `minor` / `major` with a task-specific error instead of falling through to the generic version parser
- add focused task coverage for keyword rejection and no-argument dry-run defaulting to the current gem version

## Validation

- `bundle exec rspec spec/cypress_on_rails/release_rake_spec.rb`
- `ruby -c rakelib/release.rake`
- `git diff --check`
- `bundle exec rake`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `sync_github_release` now rejects semver keywords like `patch`, `minor`, and `major` when a specific version is required.
  * Clearer error messaging now points users to provide an explicit version, such as `1.21.0` or `1.21.0.rc.0`.
  * Dry-run behavior now uses the current gem version when no version is provided and includes it in the output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->