### PR TITLE
[codex] Make sync release spec hermetic

### DIFF
--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -559,6 +559,18 @@ def perform_release(gem_version:, dry_run:, check_uncommitted: true, allow_versi
   }
 end
 
+def perform_sync_github_release(gem_root:, version_input:, dry_run:)
+  version = version_input.to_s.strip
+  version = current_gem_version(gem_root) if version.empty?
+  if semver_keyword?(version)
+    abort "sync_github_release expects an explicit version like 1.21.0 or 1.21.0.rc.0; semver keywords are only supported by the release task."
+  end
+  validate_requested_version_input!(version)
+
+  verify_gh_auth(gem_root: gem_root) unless dry_run
+  sync_github_release_after_publish(gem_root: gem_root, gem_version: normalize_release_version_string(version), dry_run: dry_run)
+end
+
 desc("Releases the gem using the given version.
 
 Recommended flow:
@@ -598,14 +610,6 @@ Arguments:
 ")
 task :sync_github_release, %i[gem_version dry_run] do |_t, args|
   gem_root = File.expand_path("..", __dir__)
-  version = args[:gem_version].to_s.strip
-  version = current_gem_version(gem_root) if version.empty?
-  if semver_keyword?(version)
-    abort "sync_github_release expects an explicit version like 1.21.0 or 1.21.0.rc.0; semver keywords are only supported by the release task."
-  end
-  validate_requested_version_input!(version)
-
   dry_run = release_truthy?(args[:dry_run])
-  verify_gh_auth(gem_root: gem_root) unless dry_run
-  sync_github_release_after_publish(gem_root: gem_root, gem_version: normalize_release_version_string(version), dry_run: dry_run)
+  perform_sync_github_release(gem_root: gem_root, version_input: args[:gem_version], dry_run: dry_run)
 end

--- a/spec/cypress_on_rails/release_rake_spec.rb
+++ b/spec/cypress_on_rails/release_rake_spec.rb
@@ -214,18 +214,16 @@ RSpec.describe "release rake helpers" do
         task.invoke("patch", "true")
       end.to raise_error(SystemExit, /sync_github_release expects an explicit version/)
     end
+  end
 
-    it "defaults to the current gem version for dry runs" do
-      task = Rake::Task["sync_github_release"]
-      task.reenable
-      gem_root = File.expand_path("../..", __dir__)
-      expected_version = current_gem_version(gem_root)
+  describe "#perform_sync_github_release" do
+    it "defaults to the current gem version for dry runs without checking GitHub auth" do
+      allow(self).to receive(:current_gem_version).with("/repo").and_return("1.20.0")
+      expect(self).not_to receive(:verify_gh_auth)
+      expect(self).to receive(:sync_github_release_after_publish)
+        .with(gem_root: "/repo", gem_version: "1.20.0", dry_run: true)
 
-      output = capture_stdout do
-        task.invoke(nil, "true")
-      end
-
-      expect(output).to include("DRY RUN: Would create or update GitHub release v#{expected_version}")
+      perform_sync_github_release(gem_root: "/repo", version_input: "", dry_run: true)
     end
   end
 


### PR DESCRIPTION
## Summary

Follow-up to #234.

- extract `perform_sync_github_release` so the sync-release behavior can be tested with stubs
- replace the non-hermetic dry-run task spec with a helper-level spec that verifies default-version behavior without touching real git tags, CHANGELOG state, or network
- keep the task-level semver keyword rejection coverage

## Validation

- `bundle exec rspec spec/cypress_on_rails/release_rake_spec.rb`
- `ruby -c rakelib/release.rake`
- `git diff --check`
- `bundle exec rake`
