### PR TITLE
Update changelog for 1.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,12 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-### Fixed
-* **Rails 8.1 compatibility**: Require ActiveSupport delegation explicitly so the railtie loads under Rails 8.1. [PR 207](https://github.com/shakacode/cypress-playwright-on-rails/pull/207)
-* **Playwright helpers return parsed JSON**: `appCommands`, `appVcrInsertCassette`, and `appVcrEjectCassette` in the generated Playwright `on-rails.js` now return `response.json()` instead of a `Buffer`. [PR 219](https://github.com/shakacode/cypress-playwright-on-rails/pull/219) by [helio3197](https://github.com/helio3197) (originally [PR 168](https://github.com/shakacode/cypress-playwright-on-rails/pull/168))
-* Generated initializer and `e2e_helper.rb` templates no longer contain trailing spaces. [PR 205](https://github.com/shakacode/cypress-playwright-on-rails/pull/205) by [tnir](https://github.com/tnir)
+## [1.20.1] - 2026-07-10
 
-### Changed
-* The managed test server no longer overrides `RAILS_ENV` when it is already set, so E2E runs can target the test (or any) environment. [PR 210](https://github.com/shakacode/cypress-playwright-on-rails/pull/210) by [arielj](https://github.com/arielj)
+### Fixed
+- **Rails 8.1 compatibility**: Required ActiveSupport delegation explicitly so the railtie loads under Rails 8.1. [PR 207](https://github.com/shakacode/cypress-playwright-on-rails/pull/207) by [justin808](https://github.com/justin808).
+- **Playwright helper JSON responses**: Updated generated `appCommands`, `appVcrInsertCassette`, and `appVcrEjectCassette` helpers to return parsed JSON rather than a `Buffer`. [PR 219](https://github.com/shakacode/cypress-playwright-on-rails/pull/219) by [justin808](https://github.com/justin808).
+- **Configured Rails environment**: Preserved an existing `RAILS_ENV` when starting the managed test server, allowing E2E runs to target a configured environment. [PR 210](https://github.com/shakacode/cypress-playwright-on-rails/pull/210) by [arielj](https://github.com/arielj).
 
 ---
 
@@ -532,6 +531,9 @@ If migrating from the `cypress-rails` gem:
 [#201]: https://github.com/shakacode/cypress-playwright-on-rails/issues/201
 
 <!-- Version diff reference list -->
+[unreleased]: https://github.com/shakacode/cypress-playwright-on-rails/compare/v1.20.1...master
+[1.20.1]: https://github.com/shakacode/cypress-playwright-on-rails/compare/v1.20.0...v1.20.1
+[1.20.0]: https://github.com/shakacode/cypress-playwright-on-rails/compare/v1.19.0...v1.20.0
 [1.19.0]: https://github.com/shakacode/cypress-playwright-on-rails/compare/v1.18.0...v1.19.0
 [1.18.0]: https://github.com/shakacode/cypress-playwright-on-rails/compare/v1.17.0...v1.18.0
 [1.17.0]: https://github.com/shakacode/cypress-playwright-on-rails/compare/v1.16.0...v1.17.0


### PR DESCRIPTION
## Summary
- Stamp the 1.20.1 changelog section.
- Document Rails 8.1 compatibility, Playwright JSON helper responses, and configured `RAILS_ENV` support.
- Exclude formatting-only and internal release/CI/documentation changes.

## Validation
- `bundle exec rake`