### PR TITLE
Harden docs workflow checks from PR #236

### DIFF
--- a/.github/workflows/trigger-docs-site.yml
+++ b/.github/workflows/trigger-docs-site.yml
@@ -14,7 +14,7 @@ jobs:
   notify-docs-site:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547
         id: app-token
         with:
           app-id: ${{ secrets.DOCS_DISPATCH_APP_ID }}

--- a/.github/workflows/trigger-docs-site.yml
+++ b/.github/workflows/trigger-docs-site.yml
@@ -14,7 +14,7 @@ jobs:
   notify-docs-site:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547
+      - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         id: app-token
         with:
           app-id: ${{ secrets.DOCS_DISPATCH_APP_ID }}

--- a/script/check-docs-sidebar
+++ b/script/check-docs-sidebar
@@ -24,10 +24,24 @@ if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
   git fetch --no-tags --depth=50 origin master:refs/remotes/origin/master >/dev/null 2>&1 || true
 fi
 
-if MERGE_BASE=$(git merge-base "$BASE_REF" "$CURRENT_REF" 2>/dev/null); then
-  ADDED_FILES=$(git diff --name-only --diff-filter=AR "$MERGE_BASE" "$CURRENT_REF")
-else
-  ADDED_FILES=$(git diff --name-only --diff-filter=AR "$BASE_REF" "$CURRENT_REF" 2>/dev/null || echo "")
+if ! git rev-parse --verify "${BASE_REF}^{commit}" >/dev/null 2>&1; then
+  echo -e "${RED}Error: cannot resolve base ref: $BASE_REF${NC}" >&2
+  exit 1
+fi
+
+if ! git rev-parse --verify "${CURRENT_REF}^{commit}" >/dev/null 2>&1; then
+  echo -e "${RED}Error: cannot resolve current ref: $CURRENT_REF${NC}" >&2
+  exit 1
+fi
+
+if ! MERGE_BASE=$(git merge-base "$BASE_REF" "$CURRENT_REF" 2>/dev/null); then
+  echo -e "${RED}Error: cannot compute comparison between $BASE_REF and $CURRENT_REF${NC}" >&2
+  exit 1
+fi
+
+if ! ADDED_FILES=$(git diff --name-only --diff-filter=AR "$MERGE_BASE" "$CURRENT_REF"); then
+  echo -e "${RED}Error: cannot compute comparison between $BASE_REF and $CURRENT_REF${NC}" >&2
+  exit 1
 fi
 
 if [ -z "${CI:-}" ] && [ "$CURRENT_REF" = "HEAD" ]; then

--- a/script/check-docs-sidebar
+++ b/script/check-docs-sidebar
@@ -35,12 +35,12 @@ if ! git rev-parse --verify "${CURRENT_REF}^{commit}" >/dev/null 2>&1; then
 fi
 
 if ! MERGE_BASE=$(git merge-base "$BASE_REF" "$CURRENT_REF" 2>/dev/null); then
-  echo -e "${RED}Error: cannot compute comparison between $BASE_REF and $CURRENT_REF${NC}" >&2
+  echo -e "${RED}Error: cannot find merge base between $BASE_REF and $CURRENT_REF${NC}" >&2
   exit 1
 fi
 
 if ! ADDED_FILES=$(git diff --name-only --diff-filter=AR "$MERGE_BASE" "$CURRENT_REF"); then
-  echo -e "${RED}Error: cannot compute comparison between $BASE_REF and $CURRENT_REF${NC}" >&2
+  echo -e "${RED}Error: cannot diff comparison between $BASE_REF and $CURRENT_REF${NC}" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Follow-up to merged PR #236. This resolves its verified review findings by making the docs sidebar gate fail closed when either comparison ref cannot be resolved and by pinning the GitHub App token action to the verified v1 commit.

## Scope

- fail clearly for an invalid base ref, invalid current ref, merge-base failure, or diff failure
- preserve the existing valid docs/sidebar behavior
- pin `actions/create-github-app-token` to `d72941d797fd3113feb6b93fd0dec494b13a2547`
- leave the quoted exact-ID sidebar matching unchanged because the reported prefix collision does not reproduce

## Validation

- invalid base ref: exits 1 with a clear diagnostic
- invalid current ref: exits 1 with a clear diagnostic
- `script/check-docs-sidebar HEAD^ HEAD`: passes for all 9 docs added by #236
- `bash -n script/check-docs-sidebar`
- ShellCheck
- actionlint for both docs workflows
- Ruby YAML parse for both docs workflows
- `bundle exec rake`: 71 examples, 0 failures
- `git diff --check`
- independent Codex review: clean at `0e766b76f4635fa4b35d6b5720829e51fca5d1ea`

## Workflow rollout

This is a semantic workflow hardening change: the trigger and permissions are unchanged, no secret references are added, and no new action is introduced. The existing token-minting action changes from a floating v1 tag to the commit currently referenced by that v1 tag. The required post-merge exercise is tracked in #241.

Stale-base race control: open PRs touching the enforced docs surface were swept. PR #191 touches docs and must update to current `master` and rerun the sidebar checker/current CI before it merges. No open PR directly collides with either changed file in this correction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved documentation-site automation reliability and security.
  * Documentation updates continue to trigger site rebuilds as expected.
  * Strengthened documentation sidebar checks to handle missing or invalid revision references more clearly.
  * Improved file comparison accuracy when validating documentation changes, helping prevent incorrect sidebar validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Agent Merge Confidence

- Current head: `4e4657a42bd0bb43bc6bd2aa5fc31bf52c3d3282`
- Local validation: docs checker failure modes, ShellCheck, actionlint, YAML parse, and `bundle exec rake` (71 examples, 0 failures)
- Independent review: clean; all current hosted review threads verified, triaged, and resolved
- QA: current-head `qa-evidence v1` PASS with no blockers or unknowns
- Current-head CI: READY; sidebar and Ruby matrix green
- Merge ledger: changed paths match the exact docs map; workflow audit, stale-base control, and post-merge exercise #241 are recorded; unresolved decisions 0; UNKNOWN fields 0; `complete_allowed: true`
- Release mode: workflow/docs hardening follow-up; no package release or changelog change required
- Merge authority: `auto_merge_when_gates_pass`