### PR TITLE
Report Rails server startup failures

### DIFF
--- a/lib/cypress_on_rails/server.rb
+++ b/lib/cypress_on_rails/server.rb
@@ -91,29 +91,34 @@ module CypressOnRails
         raise
       end
 
+      timeout_result = nil
+      stop_result = nil
       begin
-        wait_for_server
-        run_hook(config.after_server_start)
-        
-        puts "Rails server started on #{base_url}"
-        
-        if @transactional && defined?(ActiveRecord::Base)
-          ActiveRecord::Base.connection.begin_transaction(joinable: false)
-          run_hook(config.after_transaction_start)
+        timeout_result = wait_for_server
+        unless timeout_result
+          run_hook(config.after_server_start)
+
+          puts "Rails server started on #{base_url}"
+
+          if @transactional && defined?(ActiveRecord::Base)
+            ActiveRecord::Base.connection.begin_transaction(joinable: false)
+            run_hook(config.after_transaction_start)
+          end
+
+          yield
         end
-        
-        yield
-        
       ensure
         run_hook(config.before_server_stop)
-        
+
         if @transactional && defined?(ActiveRecord::Base)
           ActiveRecord::Base.connection.rollback_transaction if ActiveRecord::Base.connection.transaction_open?
         end
         
-        stop_server(server_pid)
+        stop_result = stop_server(server_pid)
         ENV.delete('CYPRESS')
       end
+
+      raise server_start_timeout_failure(timeout_result[:timeout], timeout_result[:status], stop_result) if timeout_result
     end
 
     def spawn_server
@@ -134,6 +139,7 @@ module CypressOnRails
       start_server_output_capture
       begin
         @server_pid = spawn(*server_args, out: @server_stdout_writer, err: @server_stderr_writer, pgroup: true)
+        @server_pgid = @server_pid
       rescue SystemCallError, ArgumentError => error
         close_server_output_writers
         drain_server_output
@@ -141,14 +147,6 @@ module CypressOnRails
                            "process status unavailable: #{error.class}: #{error.message}"
       ensure
         close_server_output_writers
-      end
-      begin
-        @server_pgid = Process.getpgid(@server_pid)
-      rescue Errno::ESRCH => e
-        # Edge case: process terminated before we could get pgid
-        # This is OK - send_term_signal will fall back to single-process kill
-        CypressOnRails.configuration.logger.warn("Process #{@server_pid} terminated immediately after spawn: #{e.message}")
-        @server_pgid = nil
       end
       @server_pid
     end
@@ -162,10 +160,14 @@ module CypressOnRails
           sleep 0.1
         end
       end
+      nil
     rescue Timeout::Error
       raise server_start_failure if server_exited?
 
-      raise server_start_timeout_failure(timeout)
+      {
+        timeout: timeout,
+        status: process_exists?(@server_pid) ? 'process status running' : 'process status unavailable'
+      }
     end
 
     def server_responding?
@@ -189,15 +191,24 @@ module CypressOnRails
     def stop_server(pid)
       return :terminal unless pid
       begin
-        return :terminal if server_terminal? || server_exited?
+        leader_terminal = server_terminal? || server_exited?
+        return :terminal if leader_terminal && !@server_pgid
 
         puts "Stopping Rails server (PID: #{pid})"
         send_term_signal(pid)
+        if @server_pgid
+          unless wait_for_server_group_exit(monotonic_time + SERVER_STOP_TIMEOUT)
+            CypressOnRails.configuration.logger.warn("Server process group did not terminate after TERM signal, sending KILL")
+            send_kill_signal(pid)
+            wait_for_server_group_exit(monotonic_time + SERVER_STOP_TIMEOUT)
+          end
+          return leader_terminal ? :terminal_group_signaled : :signaled
+        end
 
         unless wait_for_server_exit(monotonic_time + SERVER_STOP_TIMEOUT)
           CypressOnRails.configuration.logger.warn("Server did not terminate after TERM signal, sending KILL")
           unless server_exited?
-            safe_kill_process('KILL', pid)
+            send_kill_signal(pid)
             wait_for_server_exit(monotonic_time + SERVER_STOP_TIMEOUT)
           end
         end
@@ -210,6 +221,17 @@ module CypressOnRails
     def wait_for_server_exit(deadline)
       loop do
         return true if server_exited?
+        now = monotonic_time
+        return false if now >= deadline
+
+        sleep [SERVER_STOP_POLL_INTERVAL, deadline - now].min
+      end
+    end
+
+    def wait_for_server_group_exit(deadline)
+      loop do
+        server_exited? unless server_terminal?
+        return true unless process_group_exists?
         now = monotonic_time
         return false if now >= deadline
 
@@ -324,14 +346,19 @@ module CypressOnRails
       ServerError.new(message)
     end
 
-    def server_start_timeout_failure(timeout)
-      if server_exited?
-        status = startup_process_status
-        drain_server_output
+    def server_start_timeout_failure(timeout, timeout_status = nil, stop_result = nil)
+      if timeout_status
+        status = startup_process_status if terminal_stop_result?(stop_result)
+        status ||= timeout_status
       else
-        status = process_exists?(@server_pid) ? 'process status running' : 'process status unavailable'
-        stop_result = stop_server(@server_pid)
-        status = startup_process_status if stop_result == :terminal
+        if server_exited?
+          status = startup_process_status
+          drain_server_output
+        else
+          status = process_exists?(@server_pid) ? 'process status running' : 'process status unavailable'
+          stop_result = stop_server(@server_pid)
+          status = startup_process_status if stop_result == :terminal
+        end
       end
       message = "Rails server command #{@server_command.join(' ')} failed to become ready after #{timeout} seconds with #{status}"
       output = recent_server_output
@@ -351,6 +378,10 @@ module CypressOnRails
       return 'process status unavailable' if @server_status_unavailable
 
       process_status(@server_exit_status)
+    end
+
+    def terminal_stop_result?(result)
+      result == :terminal || result == :terminal_group_signaled
     end
 
     def server_terminal?
@@ -438,14 +469,35 @@ module CypressOnRails
     end
 
     def send_term_signal(pid)
-      if @server_pgid && process_exists?(pid)
-        Process.kill('TERM', -@server_pgid)
-      else
-        safe_kill_process('TERM', pid)
+      send_server_signal('TERM', pid)
+    end
+
+    def send_kill_signal(pid)
+      send_server_signal('KILL', pid)
+    end
+
+    def send_server_signal(signal, pid)
+      if @server_pgid
+        Process.kill(signal, -@server_pgid)
+      elsif process_exists?(pid)
+        safe_kill_process(signal, pid)
       end
     rescue Errno::ESRCH, Errno::EPERM => e
+      return if server_terminal?
+
       CypressOnRails.configuration.logger.warn("Failed to kill process group #{@server_pgid}: #{e.message}, trying single process")
-      safe_kill_process('TERM', pid)
+      safe_kill_process(signal, pid) if process_exists?(pid)
+    end
+
+    def process_group_exists?
+      return false unless @server_pgid
+
+      Process.kill(0, -@server_pgid)
+      true
+    rescue Errno::ESRCH
+      false
+    rescue Errno::EPERM
+      true
     end
 
     def process_exists?(pid)

--- a/lib/cypress_on_rails/server.rb
+++ b/lib/cypress_on_rails/server.rb
@@ -2,10 +2,23 @@ require 'socket'
 require 'timeout'
 require 'fileutils'
 require 'net/http'
+require 'thread'
 require 'cypress_on_rails/configuration'
 
 module CypressOnRails
+  class ServerError < StandardError
+  end
+
   class Server
+    MAX_STARTUP_OUTPUT_BYTES = 4_096
+    MAX_STARTUP_OUTPUT_LINES = 50
+    SERVER_OUTPUT_DRAIN_TIMEOUT = 0.5
+    SERVER_OUTPUT_THREAD_JOIN_TIMEOUT = 0.05
+    SERVER_OUTPUT_FORWARD_QUEUE_SIZE = 16
+    SERVER_OUTPUT_FORWARD_BACKPRESSURE_TIMEOUT = 0.1
+    SERVER_STOP_TIMEOUT = 10
+    SERVER_STOP_POLL_INTERVAL = 0.05
+
     attr_reader :host, :port, :framework, :install_folder
 
     def initialize(options = {})
@@ -71,8 +84,13 @@ module CypressOnRails
       ENV['CYPRESS'] = '1'
       ENV['RAILS_ENV'] ||= 'test'
       
-      server_pid = spawn_server
-      
+      begin
+        server_pid = spawn_server
+      rescue StandardError
+        ENV.delete('CYPRESS')
+        raise
+      end
+
       begin
         wait_for_server
         run_hook(config.after_server_start)
@@ -109,7 +127,21 @@ module CypressOnRails
 
       puts "Starting Rails server: #{server_args.join(' ')}"
 
-      @server_pid = spawn(*server_args, out: $stdout, err: $stderr, pgroup: true)
+      @server_command = server_args
+      @server_exit_status = nil
+      @server_status_unavailable = false
+      @server_stopped = false
+      start_server_output_capture
+      begin
+        @server_pid = spawn(*server_args, out: @server_stdout_writer, err: @server_stderr_writer, pgroup: true)
+      rescue SystemCallError, ArgumentError => error
+        close_server_output_writers
+        drain_server_output
+        raise ServerError, "Rails server command #{@server_command.join(' ')} failed to spawn; " \
+                           "process status unavailable: #{error.class}: #{error.message}"
+      ensure
+        close_server_output_writers
+      end
       begin
         @server_pgid = Process.getpgid(@server_pid)
       rescue Errno::ESRCH => e
@@ -122,14 +154,18 @@ module CypressOnRails
     end
 
     def wait_for_server(timeout = 30)
-      Timeout.timeout(timeout) do
+      Timeout.timeout(timeout, Timeout::Error) do
         loop do
           break if server_responding?
+          raise server_start_failure if server_exited?
+
           sleep 0.1
         end
       end
     rescue Timeout::Error
-      raise "Rails server failed to start on #{host}:#{port} after #{timeout} seconds"
+      raise server_start_failure if server_exited?
+
+      raise server_start_timeout_failure(timeout)
     end
 
     def server_responding?
@@ -151,22 +187,254 @@ module CypressOnRails
     end
 
     def stop_server(pid)
-      return unless pid
+      return :terminal unless pid
+      begin
+        return :terminal if server_terminal? || server_exited?
 
-      puts "Stopping Rails server (PID: #{pid})"
-      send_term_signal(pid)
+        puts "Stopping Rails server (PID: #{pid})"
+        send_term_signal(pid)
+
+        unless wait_for_server_exit(monotonic_time + SERVER_STOP_TIMEOUT)
+          CypressOnRails.configuration.logger.warn("Server did not terminate after TERM signal, sending KILL")
+          unless server_exited?
+            safe_kill_process('KILL', pid)
+            wait_for_server_exit(monotonic_time + SERVER_STOP_TIMEOUT)
+          end
+        end
+        :signaled
+      ensure
+        wait_for_server_output
+      end
+    end
+
+    def wait_for_server_exit(deadline)
+      loop do
+        return true if server_exited?
+        now = monotonic_time
+        return false if now >= deadline
+
+        sleep [SERVER_STOP_POLL_INTERVAL, deadline - now].min
+      end
+    end
+
+    def start_server_output_capture
+      @server_output = +''
+      @server_output_mutex = Mutex.new
+      @server_output_streams = []
+      @server_output_readers = []
+      @server_output_forwarders = []
 
       begin
-        Timeout.timeout(10) do
-          Process.wait(pid)
+        stdout_reader, @server_stdout_writer = IO.pipe
+        @server_output_streams << [stdout_reader, SizedQueue.new(SERVER_OUTPUT_FORWARD_QUEUE_SIZE), $stdout]
+        stderr_reader, @server_stderr_writer = IO.pipe
+        @server_output_streams << [stderr_reader, SizedQueue.new(SERVER_OUTPUT_FORWARD_QUEUE_SIZE), $stderr]
+
+        @server_output_streams.each do |reader, queue, _stream|
+          @server_output_readers << start_server_output_reader(reader, queue)
         end
-      rescue Timeout::Error
-        CypressOnRails.configuration.logger.warn("Server did not terminate after TERM signal, sending KILL")
-        safe_kill_process('KILL', pid)
-        Process.wait(pid) rescue Errno::ESRCH
+        @server_output_streams.each do |_reader, queue, stream|
+          @server_output_forwarders << start_server_output_forwarder(queue, stream)
+        end
+      rescue StandardError
+        close_server_output_writers
+        Array(@server_output_streams).each do |reader, _queue, _stream|
+          reader.close unless reader.closed?
+        end
+        stop_server_output_readers
+        stop_server_output_forwarders
+        raise
       end
-    rescue Errno::ESRCH
-      # Process already terminated
+    end
+
+    def start_server_output_reader(reader, queue)
+      Thread.new do
+        forwarding = true
+        forwarding_deadline = nil
+        loop do
+          output = reader.readpartial(1_024)
+          capture_server_output(output)
+          if forwarding
+            forwarding, forwarding_deadline = enqueue_server_output(queue, output, forwarding_deadline)
+          end
+        end
+      rescue EOFError, IOError
+        # The server closed its output stream.
+      ensure
+        enqueue_server_output_end(queue, forwarding_deadline) if forwarding
+        reader.close unless reader.closed?
+      end
+    end
+
+    def start_server_output_forwarder(queue, stream)
+      Thread.new do
+        forwarding = true
+        loop do
+          output = queue.pop
+          break unless output
+
+          next unless forwarding
+
+          begin
+            stream.write(output)
+            stream.flush
+          rescue SystemCallError, IOError, EncodingError
+            forwarding = false
+          end
+        end
+      end
+    end
+
+    def capture_server_output(output)
+      @server_output_mutex.synchronize do
+        @server_output << output
+        if @server_output.bytesize > MAX_STARTUP_OUTPUT_BYTES
+          @server_output = @server_output.byteslice(-MAX_STARTUP_OUTPUT_BYTES, MAX_STARTUP_OUTPUT_BYTES)
+        end
+      end
+    end
+
+    def server_exited?
+      return true if server_terminal?
+
+      terminal = false
+      Thread.handle_interrupt(Timeout::Error => :never) do
+        begin
+          result = Process.waitpid2(@server_pid, Process::WNOHANG)
+          if result
+            @server_exit_status = result.last
+            @server_stopped = true
+            terminal = true
+          end
+        rescue Errno::ECHILD
+          @server_status_unavailable = true
+          @server_stopped = true
+          terminal = true
+        end
+      end
+      terminal
+    end
+
+    def server_start_failure
+      drain_server_output
+      status = @server_exit_status
+      message = "Rails server command #{@server_command.join(' ')} exited during startup with #{process_status(status)}"
+      output = recent_server_output
+      message += "\nRecent server output:\n#{output}" unless output.empty?
+      ServerError.new(message)
+    end
+
+    def server_start_timeout_failure(timeout)
+      if server_exited?
+        status = startup_process_status
+        drain_server_output
+      else
+        status = process_exists?(@server_pid) ? 'process status running' : 'process status unavailable'
+        stop_result = stop_server(@server_pid)
+        status = startup_process_status if stop_result == :terminal
+      end
+      message = "Rails server command #{@server_command.join(' ')} failed to become ready after #{timeout} seconds with #{status}"
+      output = recent_server_output
+      message += "\nRecent server output:\n#{output}" unless output.empty?
+      ServerError.new(message)
+    end
+
+    def process_status(status)
+      return 'process status unavailable' if @server_status_unavailable
+      return 'an unknown process status' unless status
+      return "exit status #{status.exitstatus}" if status.exited?
+
+      "signal #{status.termsig}"
+    end
+
+    def startup_process_status
+      return 'process status unavailable' if @server_status_unavailable
+
+      process_status(@server_exit_status)
+    end
+
+    def server_terminal?
+      @server_exit_status || @server_status_unavailable || @server_stopped
+    end
+
+    def recent_server_output
+      @server_output_mutex.synchronize do
+        output = @server_output.each_line.to_a.last(MAX_STARTUP_OUTPUT_LINES).join
+        output = output.byteslice(-MAX_STARTUP_OUTPUT_BYTES, MAX_STARTUP_OUTPUT_BYTES) if output.bytesize > MAX_STARTUP_OUTPUT_BYTES
+        output.force_encoding(Encoding::UTF_8).scrub('')
+      end
+    end
+
+    def close_server_output_writers
+      [@server_stdout_writer, @server_stderr_writer].compact.each do |writer|
+        writer.close unless writer.closed?
+      end
+    end
+
+    def wait_for_server_output
+      drain_server_output
+    end
+
+    def drain_server_output
+      deadline = monotonic_time + SERVER_OUTPUT_DRAIN_TIMEOUT
+      close_server_output_writers
+      wait_for_server_output_readers(deadline)
+    ensure
+      Array(@server_output_streams).each do |reader, _queue, _stream|
+        reader.close unless reader.closed?
+      end
+      stop_server_output_readers
+      stop_server_output_forwarders(deadline)
+    end
+
+    def wait_for_server_output_readers(deadline)
+      Array(@server_output_readers).each do |reader|
+        timeout = deadline - monotonic_time
+        break if timeout <= 0
+
+        reader.join(timeout)
+      end
+    end
+
+    def enqueue_server_output_end(queue, deadline)
+      enqueue_server_output(queue, nil, deadline)
+    end
+
+    def enqueue_server_output(queue, output, deadline)
+      deadline = nil if deadline && queue.empty?
+      loop do
+        queue.push(output, true)
+        return [true, deadline]
+      rescue ThreadError
+        deadline ||= monotonic_time + SERVER_OUTPUT_FORWARD_BACKPRESSURE_TIMEOUT
+        return false if monotonic_time >= deadline
+
+        sleep 0.001
+      end
+    end
+
+    def stop_server_output_forwarders(deadline = nil)
+      deadline ||= monotonic_time + SERVER_OUTPUT_THREAD_JOIN_TIMEOUT
+      forwarders = Array(@server_output_forwarders)
+      forwarders.each do |forwarder|
+        timeout = deadline - monotonic_time
+        forwarder.join(timeout) if timeout > 0
+      end
+      forwarders.each do |forwarder|
+        forwarder.kill if forwarder.alive?
+        forwarder.join(SERVER_OUTPUT_THREAD_JOIN_TIMEOUT)
+      end
+    end
+
+    def stop_server_output_readers
+      Array(@server_output_readers).each do |reader|
+        reader.kill if reader.alive?
+      end
+      Array(@server_output_readers).each { |reader| reader.join(SERVER_OUTPUT_THREAD_JOIN_TIMEOUT) }
+    end
+
+    def monotonic_time
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
     end
 
     def send_term_signal(pid)

--- a/spec/cypress_on_rails/server_spec.rb
+++ b/spec/cypress_on_rails/server_spec.rb
@@ -79,6 +79,61 @@ RSpec.describe CypressOnRails::Server do
       end
     end
 
+    it 'cleans a surviving process group after its fast launcher exits' do
+      pid = 12_345
+      prepare_lifecycle_server(pid)
+      allow(server).to receive(:start_server_output_capture)
+      allow(server).to receive(:spawn).and_return(pid)
+      expect(Process).not_to receive(:getpgid)
+
+      server.send(:spawn_server)
+      server.instance_variable_set(:@server_exit_status, exited_process_status)
+      allow(server).to receive(:process_group_exists?).and_return(false)
+
+      expect(Process).to receive(:kill).with('TERM', -pid)
+      expect(server.send(:stop_server, pid)).to eq(:terminal_group_signaled)
+      expect(server.instance_variable_get(:@server_pgid)).to eq(pid)
+    end
+
+    it 'escalates a terminal leader process group to KILL after the bounded TERM wait' do
+      pid = 12_345
+      signals = []
+      prepare_lifecycle_server(pid)
+      server.instance_variable_set(:@server_pgid, pid)
+      server.instance_variable_set(:@server_exit_status, exited_process_status)
+      allow(Process).to receive(:kill) { |signal, target| signals << [signal, target] }
+      expect(server).to receive(:process_group_exists?).and_return(true, true, false)
+      allow(server).to receive(:monotonic_time).and_return(0.0, 10.0)
+      allow(server).to receive(:sleep)
+
+      expect(server.send(:stop_server, pid)).to eq(:terminal_group_signaled)
+
+      expect(signals).to eq([['TERM', -pid], ['KILL', -pid]])
+    end
+
+    it 'escalates a live leader process group after the leader exits on TERM' do
+      pid = 12_345
+      signals = []
+      polls = 0
+      prepare_lifecycle_server(pid)
+      status = exited_process_status
+      server.instance_variable_set(:@server_pgid, pid)
+      allow(Process).to receive(:waitpid2).with(pid, Process::WNOHANG) do
+        polls += 1
+        polls == 1 ? nil : [pid, status]
+      end
+      allow(Process).to receive(:kill) { |signal, target| signals << [signal, target] }
+      expect(server).to receive(:process_group_exists?).and_return(true, true, false)
+      allow(server).to receive(:monotonic_time).and_return(0.0, 10.0)
+      allow(server).to receive(:sleep)
+
+      expect(server.send(:stop_server, pid)).to eq(:signaled)
+
+      expect(signals).to eq([['TERM', -pid], ['KILL', -pid]])
+      expect(server.instance_variable_get(:@server_exit_status)).to eq(status)
+      expect(polls).to eq(2)
+    end
+
     it 'treats an externally reaped server as terminal with unavailable status without TERM' do
       prepare_lifecycle_server(12_345)
       allow(Process).to receive(:waitpid2).with(12_345, Process::WNOHANG).and_raise(Errno::ECHILD)
@@ -213,13 +268,13 @@ RSpec.describe CypressOnRails::Server do
       prepare_lifecycle_server(pid)
       allow(server).to receive(:server_exited?).and_return(false)
       allow(server).to receive(:send_term_signal) { signals << 'TERM' }
-      allow(server).to receive(:safe_kill_process) { |signal, _pid| signals << signal }
+      allow(server).to receive(:send_kill_signal) { signals << 'KILL' }
       allow(server).to receive(:wait_for_server_exit).and_return(false, true)
 
       server.send(:stop_server, pid)
 
       expect(signals).to eq(['TERM', 'KILL'])
-      expect(server).to have_received(:safe_kill_process).once.with('KILL', pid)
+      expect(server).to have_received(:send_kill_signal).once.with(pid)
     end
 
     it 'returns false without a negative sleep when the deadline passes between clock reads' do
@@ -284,6 +339,39 @@ RSpec.describe CypressOnRails::Server do
         expect(error.message).to include('still starting')
       }
       expect(signal_attempts).to eq(1)
+    end
+
+    it 'runs the stop hook before signaling a live readiness timeout' do
+      captured_output = Queue.new
+      events = []
+      allow(CypressOnRails.configuration).to receive(:before_server_stop).and_return(-> { events << :hook })
+      allow(server).to receive(:capture_server_output).and_wrap_original do |original, output|
+        original.call(output).tap { captured_output << true }
+      end
+      allow(server).to receive(:server_responding?) do
+        captured_output.pop
+        raise Timeout::Error
+      end
+      allow(server).to receive(:send_term_signal).and_wrap_original do |original, pid|
+        events << :term
+        original.call(pid)
+      end
+      spawn_running_child("final diagnostic line\n")
+      allow(Timeout).to receive(:timeout).and_wrap_original do |original, timeout, exception_class = nil, &block|
+        if timeout == 30
+          expect(exception_class).to eq(Timeout::Error)
+          block.call
+        else
+          original.call(timeout, exception_class, &block)
+        end
+      end
+
+      expect { server.open }.to raise_error(CypressOnRails::ServerError) { |error|
+        expect(error.message).to include('bundle exec rails server -p 4321 -b 127.0.0.1')
+        expect(error.message).to include('process status running')
+        expect(error.message).to include('final diagnostic line')
+      }
+      expect(events).to eq([:hook, :term])
     end
 
     it 'drains a lagging reader before building a live-timeout error' do

--- a/spec/cypress_on_rails/server_spec.rb
+++ b/spec/cypress_on_rails/server_spec.rb
@@ -1,0 +1,513 @@
+require 'cypress_on_rails/server'
+require 'rbconfig'
+require 'thread'
+require 'json'
+require 'stringio'
+
+RSpec.describe CypressOnRails::Server do
+  describe '#open' do
+    let(:server) { described_class.new(host: '127.0.0.1', port: 4321) }
+
+    before do
+      allow($stderr).to receive(:write)
+      allow(server).to receive(:server_responding?).and_return(false)
+      allow(server).to receive(:run_command)
+    end
+
+    it 'wraps a direct spawn exception with command, unavailable status, and cleaned resources' do
+      before_stop = spy('before server stop', call: nil)
+      allow(CypressOnRails.configuration).to receive(:before_server_stop).and_return(before_stop)
+      allow(server).to receive(:spawn).and_raise(Errno::ENOENT, 'bundle')
+
+      expect { server.open }.to raise_error(CypressOnRails::ServerError) { |error|
+        expect(error.message).to include('bundle exec rails server -p 4321 -b 127.0.0.1')
+        expect(error.message).to include('process status unavailable')
+        expect(error.message).to include('No such file or directory')
+      }
+      expect(ENV['CYPRESS']).to be_nil
+      expect(before_stop).not_to have_received(:call)
+      expect(server.instance_variable_get(:@server_output_readers)).to all(satisfy { |reader| !reader.alive? })
+    end
+
+    it 'cleans a partial capture setup failure before spawning the server' do
+      stdout_reader, stdout_writer = IO.pipe
+      stderr_reader, stderr_writer = IO.pipe
+      created_threads = []
+      thread_count = 0
+      allow(IO).to receive(:pipe).and_return([stdout_reader, stdout_writer], [stderr_reader, stderr_writer])
+      allow(Thread).to receive(:new).and_wrap_original do |original, &block|
+        thread_count += 1
+        raise ThreadError, 'injected capture setup failure' if thread_count == 2
+
+        thread = original.call(&block)
+        created_threads << thread
+        thread
+      end
+
+      expect { server.open }.to raise_error(ThreadError, 'injected capture setup failure')
+      expect(ENV['CYPRESS']).to be_nil
+      expect([stdout_reader, stdout_writer, stderr_reader, stderr_writer]).to all(be_closed)
+      expect(created_threads).to all(satisfy { |thread| !thread.alive? })
+    end
+
+    it 'reports an immediately exiting server with its command, status, and final output line' do
+      spawn_exiting_child("#{(1..55).map { |number| "line #{number}" }.join("\n")}\nfinal diagnostic line\n")
+
+      expect { server.open }.to raise_error(CypressOnRails::ServerError) { |error|
+        expect(error.message).to include('bundle exec rails server -p 4321 -b 127.0.0.1')
+        expect(error.message).to include('exit status 7')
+        expect(error.message).to include("\nline 7\n")
+        expect(error.message).not_to include("\nline 1\n")
+        expect(error.message).to include('final diagnostic line')
+        expect(error.message.lines.grep(/^line \d+$/).length).to eq(49)
+      }
+    end
+
+    it 'keeps a reaped exit status across repeated near-deadline polls' do
+      spawn_exiting_child("final diagnostic line\n")
+      server.send(:spawn_server)
+
+      begin
+        sleep 0.01 until server.send(:server_exited?)
+
+        expect(server.send(:server_exited?)).to be(true)
+        error = server.send(:server_start_failure)
+        expect(error).to be_a(CypressOnRails::ServerError)
+        expect(error.message).to include('exit status 7')
+      ensure
+        server.send(:drain_server_output)
+      end
+    end
+
+    it 'treats an externally reaped server as terminal with unavailable status without TERM' do
+      prepare_lifecycle_server(12_345)
+      allow(Process).to receive(:waitpid2).with(12_345, Process::WNOHANG).and_raise(Errno::ECHILD)
+      allow(server).to receive(:process_exists?).and_return(true)
+      allow(server).to receive(:send_term_signal)
+
+      error = server.send(:server_start_timeout_failure, 30)
+
+      expect(error.message).to include('process status unavailable')
+      expect(server).not_to have_received(:send_term_signal)
+    end
+
+    it 'reports a timeout-boundary zombie exit status without TERM' do
+      pid = 12_345
+      prepare_lifecycle_server(pid)
+      status = exited_process_status
+      allow(Process).to receive(:waitpid2).with(pid, Process::WNOHANG).and_return([pid, status])
+      allow(server).to receive(:process_exists?).and_return(true)
+      allow(server).to receive(:send_term_signal)
+
+      error = server.send(:server_start_timeout_failure, 30)
+
+      expect(error.message).to include('exit status 7')
+      expect(server).not_to have_received(:send_term_signal)
+    end
+
+    it 'refreshes timeout status when stop reaps the server before TERM' do
+      pid = 12_345
+      polls = 0
+      prepare_lifecycle_server(pid)
+      status = exited_process_status
+      allow(Process).to receive(:waitpid2).with(pid, Process::WNOHANG) do
+        polls += 1
+        polls == 1 ? nil : [pid, status]
+      end
+      allow(server).to receive(:process_exists?).and_return(true)
+      allow(server).to receive(:send_term_signal)
+
+      error = server.send(:server_start_timeout_failure, 30)
+
+      expect(error.message).to include('exit status 7')
+      expect(server).not_to have_received(:send_term_signal)
+      expect(polls).to eq(2)
+    end
+
+    it 'retains a reaped status before delivering an interrupted timeout' do
+      pid = 12_345
+      prepare_lifecycle_server(pid)
+      status = exited_process_status
+      target = Thread.current
+      interrupt = Queue.new
+      interrupter = Thread.new do
+        interrupt.pop
+        target.raise Timeout::Error
+      end
+      allow(Process).to receive(:waitpid2).with(pid, Process::WNOHANG) do
+        interrupt << true
+        sleep 0.01
+        [pid, status]
+      end
+
+      expect { server.send(:server_exited?) }.to raise_error(Timeout::Error)
+      expect(server.instance_variable_get(:@server_exit_status)).to eq(status)
+    ensure
+      interrupter.join
+    end
+
+    it 'caches a reaped status through a real readiness timeout' do
+      pid = 12_345
+      polls = 0
+      prepare_lifecycle_server(pid)
+      status = exited_process_status
+      allow(server).to receive(:server_responding?).and_return(false)
+      allow(Process).to receive(:waitpid2).with(pid, Process::WNOHANG) do
+        polls += 1
+        if polls == 1
+          result = [pid, status]
+          sleep 0.02
+          result
+        else
+          raise Errno::ECHILD
+        end
+      end
+
+      expect { server.send(:wait_for_server, 0.001) }.to raise_error(CypressOnRails::ServerError) { |error|
+        expect(error.message).to include('exit status 7')
+      }
+      expect(server.instance_variable_get(:@server_exit_status)).to eq(status)
+      expect(polls).to eq(1)
+    end
+
+    it 'does not KILL after a wait has already reaped the server' do
+      pid = 12_345
+      signals = []
+      prepare_lifecycle_server(pid)
+      status = exited_process_status
+      allow(server).to receive(:send_term_signal)
+      allow(server).to receive(:safe_kill_process) { |signal, _pid| signals << signal }
+      allow(Process).to receive(:waitpid2).with(pid, Process::WNOHANG).and_return([pid, status])
+      expect(Process).not_to receive(:wait).with(pid)
+      expect(Timeout).not_to receive(:timeout).with(10)
+
+      server.send(:stop_server, pid)
+
+      expect(signals).not_to include('KILL')
+      expect(server.instance_variable_get(:@server_exit_status)).to eq(status)
+    end
+
+    it 'skips KILL when the pre-KILL guard finds ECHILD after TERM' do
+      pid = 12_345
+      polls = 0
+      signals = []
+      prepare_lifecycle_server(pid)
+      allow(Process).to receive(:waitpid2).with(pid, Process::WNOHANG) do
+        polls += 1
+        polls == 1 ? nil : raise(Errno::ECHILD)
+      end
+      allow(server).to receive(:send_term_signal) { signals << 'TERM' }
+      allow(server).to receive(:safe_kill_process) { |signal, _pid| signals << signal }
+      allow(server).to receive(:wait_for_server_exit).and_return(false)
+
+      server.send(:stop_server, pid)
+
+      expect(signals).to eq(['TERM'])
+      expect(polls).to eq(2)
+      expect(server.instance_variable_get(:@server_status_unavailable)).to be(true)
+    end
+
+    it 'sends exactly one KILL when the pre-KILL guard remains live' do
+      pid = 12_345
+      signals = []
+      prepare_lifecycle_server(pid)
+      allow(server).to receive(:server_exited?).and_return(false)
+      allow(server).to receive(:send_term_signal) { signals << 'TERM' }
+      allow(server).to receive(:safe_kill_process) { |signal, _pid| signals << signal }
+      allow(server).to receive(:wait_for_server_exit).and_return(false, true)
+
+      server.send(:stop_server, pid)
+
+      expect(signals).to eq(['TERM', 'KILL'])
+      expect(server).to have_received(:safe_kill_process).once.with('KILL', pid)
+    end
+
+    it 'returns false without a negative sleep when the deadline passes between clock reads' do
+      sleeps = []
+      allow(server).to receive(:server_exited?).and_return(false)
+      allow(server).to receive(:monotonic_time).and_return(0.999, 1.001)
+      allow(server).to receive(:sleep) { |duration| sleeps << duration }
+
+      expect(server.send(:wait_for_server_exit, 1.0)).to be(false)
+      expect(sleeps).to all(be >= 0)
+    end
+
+    it 'bounds a pathological output line without losing the final diagnostic line' do
+      spawn_exiting_child("#{'a' * 8_192}\nfinal diagnostic line\n")
+
+      expect { server.open }.to raise_error(CypressOnRails::ServerError) { |error|
+        expect(error.message).to include('final diagnostic line')
+        expect(error.message.bytesize).to be < 5_000
+      }
+    end
+
+    it 'keeps a multibyte startup-output tail valid and serializable' do
+      final_diagnostic = "final diagnostic line\n"
+      tail = "#{'b' * (4_094 - final_diagnostic.bytesize)}#{final_diagnostic}"
+      spawn_exiting_child("#{'a' * 10}€#{tail}")
+
+      expect { server.open }.to raise_error(CypressOnRails::ServerError) { |error|
+        expect(error.message.encoding).to eq(Encoding::UTF_8)
+        expect(error.message).to be_valid_encoding
+        expect(error.message).to include('final diagnostic line')
+        expect { JSON.generate(error.message) }.not_to raise_error
+      }
+    end
+
+    it 'reports a live server readiness timeout with its command, running status, and output' do
+      captured_output = Queue.new
+      signal_attempts = 0
+      allow(server).to receive(:capture_server_output).and_wrap_original do |original, output|
+        original.call(output).tap { captured_output << true }
+      end
+      allow(server).to receive(:send_term_signal).and_wrap_original do |original, pid|
+        signal_attempts += 1
+        original.call(pid)
+      end
+      allow(server).to receive(:server_responding?) do
+        captured_output.pop
+        raise Timeout::Error
+      end
+      spawn_running_child("still starting\n")
+      allow(Timeout).to receive(:timeout).and_wrap_original do |original, timeout, exception_class = nil, &block|
+        if timeout == 30
+          expect(exception_class).to eq(Timeout::Error)
+          block.call
+        else
+          original.call(timeout, exception_class, &block)
+        end
+      end
+
+      expect { server.open }.to raise_error(CypressOnRails::ServerError) { |error|
+        expect(error.message).to include('bundle exec rails server -p 4321 -b 127.0.0.1')
+        expect(error.message).to include('process status running')
+        expect(error.message).to include('still starting')
+      }
+      expect(signal_attempts).to eq(1)
+    end
+
+    it 'drains a lagging reader before building a live-timeout error' do
+      reader_entered = Queue.new
+      release_reader = Queue.new
+      term_started = Queue.new
+      allow(server).to receive(:capture_server_output).and_wrap_original do |original, output|
+        reader_entered << true
+        release_reader.pop
+        original.call(output)
+      end
+      allow(server).to receive(:server_responding?) do
+        reader_entered.pop
+        raise Timeout::Error
+      end
+      allow(server).to receive(:send_term_signal).and_wrap_original do |original, pid|
+        term_started << true
+        original.call(pid)
+      end
+      spawn_running_child("final diagnostic line\n")
+      allow(Timeout).to receive(:timeout).and_wrap_original do |original, timeout, exception_class = nil, &block|
+        if timeout == 30
+          expect(exception_class).to eq(Timeout::Error)
+          block.call
+        else
+          original.call(timeout, exception_class, &block)
+        end
+      end
+
+      result = Queue.new
+      opening = Thread.new do
+        begin
+          server.open
+        rescue StandardError => error
+          result << error
+        end
+      end
+      term_started.pop
+      release_reader << true
+      error = result.pop
+      opening.join
+
+      expect(error).to be_a(CypressOnRails::ServerError)
+      expect(error.message).to include('final diagnostic line')
+      expect(term_started.size).to eq(0)
+    end
+
+    it 'captures final output after terminal forwarding raises EPIPE' do
+      allow($stderr).to receive(:write).and_raise(Errno::EPIPE)
+      spawn_exiting_child("first output\n", "sleep 0.05; STDERR.write('final diagnostic line\\n')")
+
+      expect { server.open }.to raise_error(CypressOnRails::ServerError) { |error|
+        expect(error.message).to include('final diagnostic line')
+      }
+    end
+
+    it 'captures diagnostics when terminal forwarding raises an encoding error' do
+      allow($stderr).to receive(:write) { |chunk| chunk.encode(Encoding::US_ASCII) }
+      spawn_exiting_child("€ final diagnostic line\n")
+
+      expect { server.open }.to raise_error(CypressOnRails::ServerError) { |error|
+        expect(error.message).to include('final diagnostic line')
+      }
+      expect(server.instance_variable_get(:@server_output_forwarders)).to all(satisfy { |thread| !thread.alive? })
+    end
+
+    it 'forwards every burst byte after a healthy slow terminal catches up' do
+      output = "#{'a' * (1_024 * 18)}final diagnostic line\n"
+      captured_bytes = 0
+      capture_ready = Queue.new
+      sink_started = Queue.new
+      release_sink = Queue.new
+      received = +''.b
+      first_write = true
+      allow(server).to receive(:capture_server_output).and_wrap_original do |original, chunk|
+        original.call(chunk)
+        captured_bytes += chunk.bytesize
+        capture_ready << true if captured_bytes >= 1_024 * 18
+      end
+      allow($stderr).to receive(:write) do |chunk|
+        if first_write
+          first_write = false
+          sink_started << true
+          release_sink.pop
+        end
+        received << chunk
+      end
+      spawn_exiting_child(output)
+
+      result = Queue.new
+      opening = Thread.new do
+        begin
+          server.open
+        rescue StandardError => error
+          result << error
+        end
+      end
+      sink_started.pop
+      capture_ready.pop
+      release_sink << true
+      error = result.pop
+      opening.join
+
+      expect(error).to be_a(CypressOnRails::ServerError)
+      expect(received).to eq(output.b)
+    end
+
+    it 'drains every byte to a healthy continuously slow terminal within the drain budget' do
+      output = "#{'a' * (1_024 * 18)}final diagnostic line\n"
+      received = +''.b
+      allow($stderr).to receive(:write) do |chunk|
+        received << chunk
+        sleep 0.01
+      end
+      spawn_exiting_child(output)
+
+      expect { server.open }.to raise_error(CypressOnRails::ServerError)
+
+      expect(received).to eq(output.b)
+      expect(server.instance_variable_get(:@server_output_forwarders)).to all(satisfy { |thread| !thread.alive? })
+    end
+
+    it 'keeps the final diagnostic when a terminal remains stalled beyond the forwarding backlog' do
+      sink_started = Queue.new
+      never_release_sink = Queue.new
+      output = "#{'a' * (1_024 * 18)}final diagnostic line\n"
+      allow($stderr).to receive(:write) do
+        sink_started << true
+        never_release_sink.pop
+      end
+      spawn_exiting_child(output)
+
+      result = Queue.new
+      opening = Thread.new do
+        begin
+          server.open
+        rescue StandardError => error
+          result << error
+        end
+      end
+      sink_started.pop
+      error = Timeout.timeout(3) { result.pop }
+      opening.join(1)
+
+      expect(error).to be_a(CypressOnRails::ServerError)
+      expect(error.message).to include('final diagnostic line')
+      expect(opening).not_to be_alive
+      expect(server.instance_variable_get(:@server_output_readers)).to all(satisfy { |reader| !reader.alive? })
+      expect(server.instance_variable_get(:@server_output_forwarders)).to all(satisfy { |forwarder| !forwarder.alive? })
+    end
+
+    it 'keeps the final diagnostic when a terminal drains the forwarding queue gradually' do
+      sink_started = Queue.new
+      output = "#{'a' * (1_024 * 48)}final diagnostic line\n"
+      reader = StringIO.new(output)
+      queue = SizedQueue.new(described_class::SERVER_OUTPUT_FORWARD_QUEUE_SIZE)
+      allow($stderr).to receive(:write) do
+        sink_started << true
+        sleep 0.02
+      end
+      server.instance_variable_set(:@server_output, +'')
+      server.instance_variable_set(:@server_output_mutex, Mutex.new)
+      server.instance_variable_set(:@server_output_streams, [[reader, queue, $stderr]])
+      server.instance_variable_set(:@server_output_readers, [server.send(:start_server_output_reader, reader, queue)])
+      server.instance_variable_set(:@server_output_forwarders, [server.send(:start_server_output_forwarder, queue, $stderr)])
+
+      sink_started.pop
+      server.send(:drain_server_output)
+
+      expect(server.send(:recent_server_output)).to include('final diagnostic line')
+      expect(server.instance_variable_get(:@server_output_readers)).to all(satisfy { |thread| !thread.alive? })
+      expect(server.instance_variable_get(:@server_output_forwarders)).to all(satisfy { |thread| !thread.alive? })
+    end
+
+    it 'retains a chunk already read by a capture reader while draining' do
+      entered_capture = Queue.new
+      release_capture = Queue.new
+      allow(server).to receive(:capture_server_output).and_wrap_original do |original, output|
+        entered_capture << true
+        release_capture.pop
+        original.call(output)
+      end
+      spawn_exiting_child("final diagnostic line\n")
+
+      pid = server.send(:spawn_server)
+      entered_capture.pop
+      draining = Thread.new { server.send(:drain_server_output) }
+      sleep 0.05
+      release_capture << true
+      draining.join
+      Process.wait(pid)
+
+      expect(server.send(:recent_server_output)).to include('final diagnostic line')
+    end
+
+    def spawn_exiting_child(output, after_output = nil)
+      allow(server).to receive(:spawn) do |*_command, **options|
+        script = ["STDERR.write(#{output.dump})", after_output, 'exit 7'].compact.join('; ')
+        Process.spawn(RbConfig.ruby, '-e', script, **options)
+      end
+    end
+
+    def spawn_running_child(output)
+      allow(server).to receive(:spawn) do |*_command, **options|
+        Process.spawn(RbConfig.ruby, '-e', "STDERR.write(#{output.dump}); sleep 10", **options)
+      end
+    end
+
+    def prepare_lifecycle_server(pid)
+      server.instance_variable_set(:@server_pid, pid)
+      server.instance_variable_set(:@server_command, ['bundle', 'exec', 'rails', 'server'])
+      server.instance_variable_set(:@server_exit_status, nil)
+      server.instance_variable_set(:@server_status_unavailable, false)
+      server.instance_variable_set(:@server_stopped, false)
+      server.instance_variable_set(:@server_output, +'')
+      server.instance_variable_set(:@server_output_mutex, Mutex.new)
+      server.instance_variable_set(:@server_output_streams, [])
+      server.instance_variable_set(:@server_output_readers, [])
+      server.instance_variable_set(:@server_output_forwarders, [])
+    end
+
+    def exited_process_status
+      pid = Process.spawn(RbConfig.ruby, '-e', 'exit 7')
+      Process.wait2(pid).last
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Rails server startup failures now surface as `CypressOnRails::ServerError` with the exact command, process status, and a bounded tail of recent output. Direct spawn errors, immediate exits, and readiness timeouts retain useful diagnostics while cleanup remains bounded and safe around process-reaping races, stalled terminals, broken pipes, and incompatible terminal encodings.

This is delivery 1 only. Shutdown configuration, port selection, Puma behavior, state reset, and #186 remain out of scope.

Related: #185

## Validation

- `bundle exec rspec spec/cypress_on_rails/server_spec.rb` — 28 examples, 0 failures
- `bundle exec rake` — 99 examples, 0 failures
- Ruby 2.7.8 and current-Ruby syntax checks — passed for both changed files
- Independent Sol/xhigh closeout review — CLEAN after lifecycle, timeout, output, and signal-race regressions
- `git diff --check` — passed

## New concepts

### Interrupt-safe process reaping

Reaping a child and caching its exit status must behave as one indivisible transition. The readiness timeout therefore raises an explicit `Timeout::Error`, while the short `waitpid2`/cache section defers that exact exception:

```ruby
# Preserve the status before delivering a pending readiness timeout.
Thread.handle_interrupt(Timeout::Error => :never) do
  result = Process.waitpid2(pid, Process::WNOHANG)
  cache_status(result.last) if result
end
```

This avoids signaling a PID after its child was already reaped and keeps failure messages accurate at timeout boundaries. It is appropriate for small, bounded state transitions; it should not wrap blocking cleanup that could hang indefinitely.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/gpt--5.6--terra_%28high%29-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated server startup/shutdown error type with richer context.
  * Bounded and more resilient capture/forwarding of server startup output (bytes/lines) with improved handling for terminal and pipe failures.
* **Bug Fixes**
  * Improved server startup readiness handling, including clearer outcomes for early exits vs timeouts.
  * More reliable process-group-aware shutdown with safe escalation when needed.
  * Prevented leaked processes, pipes, threads, and ensured captured diagnostics are preserved.
* **Tests**
  * Added an extensive RSpec test suite covering lifecycle edge cases and output-capture/forwarding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Agent Merge Confidence

- Current head: `928d5b9d826c6f8df90b4b51d92e84c1f8fd0ac9`
- Local validation: focused server spec 28 examples/0 failures; full `bundle exec rake` 99 examples/0 failures; Ruby 2.7/current syntax and diff checks passed.
- Independent review: Sol/xhigh closeout review CLEAN after real process-group lifecycle reproductions.
- Hosted review: current-head Claude and CodeRabbit checks passed; all review threads resolved.
- Batch QA: PASS with runtime, workflow/docs integration, clean-apply, and merge-tree evidence; no blockers, non-blockers, or UNKNOWN facts.
- Current-head CI: READY; Rails 6.1, Rails 7.2, Rails 8, Claude review, and CodeRabbit green. Rails 6.1 retry passed after the first attempt was canceled during externally slow Ubuntu mirror downloads.
- Merge ledger: base `07bf729f5a29ff71fcedc625186ac3d2da95b349`; exactly `lib/cypress_on_rails/server.rb` and `spec/cypress_on_rails/server_spec.rb`; unresolved review threads 0; pending/failing/unknown gates 0; complete allowed.
- Release mode: issue #185 delivery 1 only; no CHANGELOG change because the batch file map excludes it.
- Merge authority: `auto_merge_when_gates_pass`.
