### PR TITLE
Add trusted origin for contributor intake

### DIFF
--- a/.agents/agent-workflow.yml
+++ b/.agents/agent-workflow.yml
@@ -1,4 +1,8 @@
 # Non-command agent-workflow configuration for portable shared skills.
+untrusted_contributor_intake:
+  trusted_github_host: github.com
+  trusted_github_scheme: https
+  trusted_github_repo: shakacode/cypress-playwright-on-rails
 base_branch: master
 changelog: "CHANGELOG.md - user-visible changes only; version-stamp via bundle exec rake update_changelog[release|rc|beta|VERSION]; PR links use [PR N](https://github.com/shakacode/cypress-playwright-on-rails/pull/N) by [username](https://github.com/username)."
 follow_up_prefix: "Follow-up:"


### PR DESCRIPTION
## What changed

Add the explicit trusted GitHub host, scheme, and repository policy required by the `untrusted-contributor-intake` workflow.

## Why

Outside-contributor intake currently blocks before reading PR metadata because `.agents/agent-workflow.yml` does not define the trusted origin. These values pin intake to this repository on GitHub over HTTPS and remove that maintenance workflow gap.

## Impact

Maintainers can safely run metadata-and-diff-only intake for fork pull requests. This does not change runtime gem behavior.

## Validation

- `git diff --check`
- Ruby YAML parse plus exact-value assertion: passed
- `codex review --uncommitted`: clean; no actionable findings
- `.agents/bin/validate`: reached 99 examples but failed in two existing slow-terminal server-output timing specs
- Isolated rerun of those same two specs reproduced both failures; the patch changes only `.agents/agent-workflow.yml`

No changelog entry: this is maintainer workflow configuration only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated contributor intake workflow configuration with trusted connection details for improved handling of external contributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->