### PR TITLE
Configure direct merge submission

### DIFF
--- a/.agents/agent-workflow.yml
+++ b/.agents/agent-workflow.yml
@@ -4,6 +4,8 @@ untrusted_contributor_intake:
   trusted_github_scheme: https
   trusted_github_repo: shakacode/cypress-playwright-on-rails
 base_branch: master
+merge_submission:
+  mode: direct
 changelog: "CHANGELOG.md - user-visible changes only; version-stamp via bundle exec rake update_changelog[release|rc|beta|VERSION]; PR links use [PR N](https://github.com/shakacode/cypress-playwright-on-rails/pull/N) by [username](https://github.com/username)."
 follow_up_prefix: "Follow-up:"
 review_gate: "Ruby workflow green on the PR, local bundle exec rake evidence, and all review threads resolved."


### PR DESCRIPTION
## Summary
- explicitly configure the agent-workflow merge submission mode as `direct`
- leave GitHub repository and Merge Queue settings unchanged

## Validation
- Ruby YAML parse and direct-mode assertion
- seam doctor against `shakacode/agent-workflows` main at `845ab026`
- `git diff --check`

Source dependency: shakacode/agent-workflows#407 (merged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the agent workflow configuration to enable direct submission merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->