### PR TITLE
Add changelog entry for server startup diagnostics (#243)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- **Rails server startup diagnostics**: Startup failures, immediate exits, and readiness timeouts now raise `CypressOnRails::ServerError` with the exact command, process status, and a bounded tail of server output, and shutdown is process-group aware with TERM-then-KILL escalation. [PR 243](https://github.com/shakacode/cypress-playwright-on-rails/pull/243) by [justin808](https://github.com/justin808).
+
 ## [1.20.1] - 2026-07-10
 
 ### Fixed


### PR DESCRIPTION
## Why

PR #243 shipped `CypressOnRails::ServerError` and process-group-aware shutdown with TERM-then-KILL escalation, but landed without a CHANGELOG entry (its batch file map excluded `CHANGELOG.md`). The `## [Unreleased]` section was empty even though this is the only user-visible change on `master` since v1.20.1, so the next release notes would have omitted it.

## What changed

- One entry under `## [Unreleased]` → `### Changed` describing the new startup diagnostics and shutdown escalation, in the repo's `[PR N](...) by [user](...)` format.

## How to review and verify

- Compare the entry against the #243 PR description and `lib/cypress_on_rails/server.rb` (`ServerError`, `pgroup: true`, KILL escalation).
- `.agents/bin/validate` (`bundle exec rake`): 99 examples, 0 failures, run locally on this head.
- File ends with a trailing newline.

Part of the 2026-09-03 release triage; #185 delivery 1 is the source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the unreleased changelog to document clearer Rails server startup diagnostics.
  - Startup failures, unexpected exits, and readiness timeouts now provide the failed command, process status, and a limited portion of server output.
  - The documentation also notes improved shutdown handling when stopping server processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->