### PR TITLE
Add the e2e_on_rails alias gem and publish it from rake release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ spec/examples.txt
 .idea
 spec/test.log
 pkg/*.gem
+*.gem
 vendor/bundle
 .vscode
 node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **`e2e_on_rails` alias gem**: Added a thin wrapper gem that reserves the canonical name adopted at 2.0 and installs the matching `cypress-on-rails` version, and taught `rake release` to publish it after the main gem. [PR 251](https://github.com/shakacode/cypress-playwright-on-rails/pull/251) by [justin808](https://github.com/justin808).
+
 ### Changed
 - **Rails server startup diagnostics**: Startup failures, immediate exits, and readiness timeouts now raise `CypressOnRails::ServerError` with the exact command, process status, and a bounded tail of server output, and shutdown is process-group aware with TERM-then-KILL escalation. [PR 243](https://github.com/shakacode/cypress-playwright-on-rails/pull/243) by [justin808](https://github.com/justin808).
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ group :test, :development do
 end
 ```
 
+Also available as `e2e_on_rails`, the future 2.0 name (see [ADR-0001](docs/adr/0001-reserve-e2e_on_rails-rename-at-2.0.md)).
+
 Generate the boilerplate code using:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ group :test, :development do
 end
 ```
 
-Also available as `e2e_on_rails`, the future 2.0 name (see [ADR-0001](docs/adr/0001-reserve-e2e_on_rails-rename-at-2.0.md)).
+Starting with 1.21.0 the gem is also published as `e2e_on_rails`, the future 2.0 name (see [ADR-0001](docs/adr/0001-reserve-e2e_on_rails-rename-at-2.0.md)).
 
 Generate the boilerplate code using:
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,7 +5,7 @@ update and stamp the changelog first, merge that PR, then run the release task w
 
 ## The Two Gems
 
-Each release publishes two gems at the same version:
+From 1.21.0 onward, each release publishes two gems at the same version:
 
 | Gem | Source | Purpose |
 | --- | --- | --- |
@@ -35,17 +35,20 @@ root raises a descriptive error instead of packaging the wrong files.
 ## Prerequisites
 
 1. Maintainer access to `shakacode/cypress-playwright-on-rails`.
-2. RubyGems publish access for `cypress-on-rails` and `e2e_on_rails`.
+2. RubyGems publish access for `cypress-on-rails`, and for `e2e_on_rails` once it has been published (see below).
 3. Authenticated GitHub CLI with write access: `gh auth status`.
 4. Clean checkout on `master`.
 5. Dependencies installed: `bundle install`.
 
 ### One-time: first publish of `e2e_on_rails`
 
-`e2e_on_rails` has never been published. RubyGems will not accept a push from
-Nothing blocks the push technically — a first `gem push` creates the gem and
-makes the pusher its owner. The first publish is a deliberate manual step for
-three reasons:
+`e2e_on_rails` has never been published, and its first publish happens as part of
+the 1.21.0 release — the same release the README points at. Nothing is pushed
+ahead of that: the alias is always built at the release version, so the first
+published alias is 1.21.0.
+
+The push itself is not blocked technically; a first `gem push` creates the gem
+and makes the pusher its owner. It needs a human in the loop for three reasons:
 
 - ADR-0001 requires re-checking on rubygems.org that the name is still unclaimed
   immediately before the first publish. That check needs a human.
@@ -53,31 +56,35 @@ three reasons:
   purpose and co-maintainers added right away, not left to whoever runs the
   next release.
 - The alias pins `cypress-on-rails` to the exact same version, so that version
-  must already be live on RubyGems when the alias is pushed. Publishing the
-  alias first leaves it uninstallable until the parent lands.
+  must already be live on RubyGems when the alias is pushed. The alias is never
+  pushed before the main gem.
 
-Steps:
+Steps, during the 1.21.0 release:
 
-1. Re-verify the name is still unclaimed: `gem owner e2e_on_rails` should report
-   that the gem does not exist. If someone else has claimed it, stop and revisit
-   ADR-0001 before releasing.
-2. After `cypress-on-rails VERSION` is live on RubyGems, from an up-to-date
-   `master` at that same version:
+1. Before releasing, re-verify the name is still unclaimed: `gem owner e2e_on_rails`
+   should report that the gem does not exist. If someone else has claimed it,
+   stop and revisit ADR-0001 before releasing.
+2. Run `bundle exec rake release` as usual. It publishes `cypress-on-rails 1.21.0`
+   first, then builds and pushes `e2e_on_rails 1.21.0`. With MFA you are prompted
+   for a second OTP for that push.
+3. Only if the alias push fails — a mistyped second OTP is the likeliest cause —
+   push it by hand. The main gem is already live and unaffected, so this is a
+   retry, not a rollback:
 
    ```bash
    (cd alias_gem && gem build e2e_on_rails.gemspec)
-   gem push alias_gem/e2e_on_rails-VERSION.gem   # asks for your RubyGems OTP
-   rm alias_gem/e2e_on_rails-VERSION.gem
+   gem push alias_gem/e2e_on_rails-1.21.0.gem   # asks for your RubyGems OTP
+   rm alias_gem/e2e_on_rails-1.21.0.gem
    ```
 
-3. Confirm ownership and add the other release maintainers:
+4. Confirm ownership and add the other release maintainers:
 
    ```bash
    gem owner e2e_on_rails
    gem owner e2e_on_rails --add EMAIL
    ```
 
-After that first push, `rake release` handles the alias automatically on every
+After that first publish, `rake release` handles the alias automatically on every
 subsequent release.
 
 ## Recommended Flow

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,8 +13,10 @@ Each release publishes two gems at the same version:
 | `e2e_on_rails` | `alias_gem/` | thin alias that reserves the canonical name adopted at 2.0 (see `docs/adr/0001-reserve-e2e_on_rails-rename-at-2.0.md`) |
 
 `alias_gem/e2e_on_rails.gemspec` reads `lib/cypress_on_rails/version.rb`, so the
-alias always mirrors the parent version and depends on `cypress-on-rails ~> MAJOR.MINOR`.
-There is nothing to bump by hand.
+alias always mirrors the parent version and depends on exactly that version
+(`cypress-on-rails = VERSION`). An exact pin keeps the two gems locked together
+and lets a prerelease alias resolve the matching prerelease parent, which a
+`~>` requirement would exclude. There is nothing to bump by hand.
 
 `rake release` publishes `cypress-on-rails` first, then builds and pushes the
 alias. If the alias build or push fails, the task warns and continues — the main

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,8 +19,10 @@ and lets a prerelease alias resolve the matching prerelease parent, which a
 `~>` requirement would exclude. There is nothing to bump by hand.
 
 `rake release` publishes `cypress-on-rails` first, then builds and pushes the
-alias. If the alias build or push fails, the task warns and continues — the main
-release is never rolled back. Retry the alias on its own with:
+alias. The alias is a second `gem push`, so with MFA enabled you are prompted
+for a second OTP after the one for the main gem. If the alias build or push
+fails, the task warns and continues — the main release is never rolled back.
+Retry the alias on its own with:
 
 ```bash
 (cd alias_gem && gem build e2e_on_rails.gemspec && gem push e2e_on_rails-VERSION.gem)
@@ -41,13 +43,26 @@ root raises a descriptive error instead of packaging the wrong files.
 ### One-time: first publish of `e2e_on_rails`
 
 `e2e_on_rails` has never been published. RubyGems will not accept a push from
-`rake release` for a gem that does not exist yet unless the pushing account
-becomes its owner, so the first publish is a manual maintainer step:
+Nothing blocks the push technically — a first `gem push` creates the gem and
+makes the pusher its owner. The first publish is a deliberate manual step for
+three reasons:
+
+- ADR-0001 requires re-checking on rubygems.org that the name is still unclaimed
+  immediately before the first publish. That check needs a human.
+- Whoever pushes first becomes the sole owner, so ownership should be set on
+  purpose and co-maintainers added right away, not left to whoever runs the
+  next release.
+- The alias pins `cypress-on-rails` to the exact same version, so that version
+  must already be live on RubyGems when the alias is pushed. Publishing the
+  alias first leaves it uninstallable until the parent lands.
+
+Steps:
 
 1. Re-verify the name is still unclaimed: `gem owner e2e_on_rails` should report
    that the gem does not exist. If someone else has claimed it, stop and revisit
    ADR-0001 before releasing.
-2. From an up-to-date `master` at the version you are releasing:
+2. After `cypress-on-rails VERSION` is live on RubyGems, from an up-to-date
+   `master` at that same version:
 
    ```bash
    (cd alias_gem && gem build e2e_on_rails.gemspec)
@@ -131,7 +146,10 @@ bundle exec rake "sync_github_release[1.21.0]"
 10. Builds and pushes the `e2e_on_rails` alias gem at the same version; a failure here warns and continues.
 11. Creates or updates the GitHub release from that version's `CHANGELOG.md` section.
 
-Dry runs use a temporary git worktree so the main checkout is not dirtied.
+Dry runs use a temporary git worktree so the main checkout is not dirtied. They
+also build the alias gem inside that worktree — building is offline, so a broken
+alias gemspec surfaces before a live release — and delete the artifact. Dry runs
+never push either gem.
 
 ## Version Numbering
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,13 +3,65 @@
 This project follows the ShakaCode release shape used by Shakapacker and React on Rails:
 update and stamp the changelog first, merge that PR, then run the release task with no version argument.
 
+## The Two Gems
+
+Each release publishes two gems at the same version:
+
+| Gem | Source | Purpose |
+| --- | --- | --- |
+| `cypress-on-rails` | repository root | the real gem |
+| `e2e_on_rails` | `alias_gem/` | thin alias that reserves the canonical name adopted at 2.0 (see `docs/adr/0001-reserve-e2e_on_rails-rename-at-2.0.md`) |
+
+`alias_gem/e2e_on_rails.gemspec` reads `lib/cypress_on_rails/version.rb`, so the
+alias always mirrors the parent version and depends on `cypress-on-rails ~> MAJOR.MINOR`.
+There is nothing to bump by hand.
+
+`rake release` publishes `cypress-on-rails` first, then builds and pushes the
+alias. If the alias build or push fails, the task warns and continues — the main
+release is never rolled back. Retry the alias on its own with:
+
+```bash
+(cd alias_gem && gem build e2e_on_rails.gemspec && gem push e2e_on_rails-VERSION.gem)
+```
+
+The alias gemspec must be built from `alias_gem/`, because RubyGems resolves
+`spec.files` relative to the current directory. Building it from the repository
+root raises a descriptive error instead of packaging the wrong files.
+
 ## Prerequisites
 
 1. Maintainer access to `shakacode/cypress-playwright-on-rails`.
-2. RubyGems publish access for `cypress-on-rails`.
+2. RubyGems publish access for `cypress-on-rails` and `e2e_on_rails`.
 3. Authenticated GitHub CLI with write access: `gh auth status`.
 4. Clean checkout on `master`.
 5. Dependencies installed: `bundle install`.
+
+### One-time: first publish of `e2e_on_rails`
+
+`e2e_on_rails` has never been published. RubyGems will not accept a push from
+`rake release` for a gem that does not exist yet unless the pushing account
+becomes its owner, so the first publish is a manual maintainer step:
+
+1. Re-verify the name is still unclaimed: `gem owner e2e_on_rails` should report
+   that the gem does not exist. If someone else has claimed it, stop and revisit
+   ADR-0001 before releasing.
+2. From an up-to-date `master` at the version you are releasing:
+
+   ```bash
+   (cd alias_gem && gem build e2e_on_rails.gemspec)
+   gem push alias_gem/e2e_on_rails-VERSION.gem   # asks for your RubyGems OTP
+   rm alias_gem/e2e_on_rails-VERSION.gem
+   ```
+
+3. Confirm ownership and add the other release maintainers:
+
+   ```bash
+   gem owner e2e_on_rails
+   gem owner e2e_on_rails --add EMAIL
+   ```
+
+After that first push, `rake release` handles the alias automatically on every
+subsequent release.
 
 ## Recommended Flow
 
@@ -73,8 +125,9 @@ bundle exec rake "sync_github_release[1.21.0]"
 6. Runs `bundle install` to verify dependencies.
 7. Commits the release metadata.
 8. Creates and pushes `vVERSION`.
-9. Publishes the gem to RubyGems.
-10. Creates or updates the GitHub release from that version's `CHANGELOG.md` section.
+9. Publishes `cypress-on-rails` to RubyGems.
+10. Builds and pushes the `e2e_on_rails` alias gem at the same version; a failure here warns and continues.
+11. Creates or updates the GitHub release from that version's `CHANGELOG.md` section.
 
 Dry runs use a temporary git worktree so the main checkout is not dirtied.
 
@@ -113,6 +166,15 @@ Fix authentication or OTP issues, then retry from the same checkout:
 ```bash
 gem release
 bundle exec rake "sync_github_release[VERSION]"
+```
+
+### Alias gem publish failure
+
+The main release already succeeded; only the alias needs a retry:
+
+```bash
+(cd alias_gem && gem build e2e_on_rails.gemspec && gem push e2e_on_rails-VERSION.gem)
+rm -f alias_gem/e2e_on_rails-VERSION.gem
 ```
 
 ### Version policy failure

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -43,12 +43,13 @@ root raises a descriptive error instead of packaging the wrong files.
 
 ### One-time: first publish of `e2e_on_rails`
 
-`e2e_on_rails` has never been published, and its first publish happens as part of
-the 1.21.0 release — the same release the README points at. Nothing is pushed
-ahead of that: `rake release` skips the alias entirely for versions below 1.21.0,
-so a 1.20.x hotfix cut from `master` publishes `cypress-on-rails` on its own.
-Prereleases of the first version do publish the alias — 1.21.0.rc.0 counts as
-1.21.0 for this check — so it can be exercised before the final release.
+`e2e_on_rails` has never been published, and its first publish happens with the
+1.21.0 release the README points at — the first 1.21.0 prerelease if one is cut,
+otherwise 1.21.0 itself. Nothing is pushed ahead of that: `rake release` skips
+the alias entirely for versions below 1.21.0, so a 1.20.x hotfix cut from
+`master` publishes `cypress-on-rails` on its own. Prereleases of the first
+version do publish the alias — 1.21.0.rc.0 counts as 1.21.0 for this check — so
+it can be exercised before the final release.
 
 The push itself is not blocked technically; a first `gem push` creates the gem
 and makes the pusher its owner. It needs a human in the loop for three reasons:
@@ -62,19 +63,29 @@ and makes the pusher its owner. It needs a human in the loop for three reasons:
   must already be live on RubyGems when the alias is pushed. The alias is never
   pushed before the main gem.
 
-Steps, during the 1.21.0 release:
+Steps, during the release that first publishes the alias:
 
-1. Before releasing, re-verify the name is still available:
+1. Before releasing, check what is on RubyGems under the name:
 
    ```bash
-   gem search --remote --exact e2e_on_rails   # no output means the name is free
+   gem search --remote --exact e2e_on_rails
    ```
 
    RubyGems has no "unclaimed" state: a name that returns no result is simply
    unregistered, and the first successful push registers it. Use the search
    rather than `gem owner`, which manages maintainers of a gem that already
-   exists and needs credentials. If the search returns a gem, someone else has
-   registered the name: stop and revisit ADR-0001 before releasing.
+   exists and needs credentials. Read the result three ways:
+
+   - **No output.** The name is free and this is the first publish. Continue
+     with the steps below — this is the moment ADR-0001 asks a human to
+     supervise.
+   - **A version we published.** Most likely an earlier 1.21.0 prerelease
+     already pushed the alias, since prereleases publish it too. Confirm with
+     `gem owner e2e_on_rails`: if it lists the release maintainers, this is an
+     ordinary subsequent release. Skip the rest of this section and release as
+     normal.
+   - **A version someone else published.** Stop and revisit ADR-0001 before
+     releasing.
 
 2. Run `bundle exec rake release` as usual. It publishes `cypress-on-rails 1.21.0`
    first, then builds and pushes `e2e_on_rails 1.21.0`. With MFA you are prompted

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,10 +18,11 @@ alias always mirrors the parent version and depends on exactly that version
 and lets a prerelease alias resolve the matching prerelease parent, which a
 `~>` requirement would exclude. There is nothing to bump by hand.
 
-`rake release` publishes `cypress-on-rails` first, then builds and pushes the
-alias. The alias is a second `gem push`, so with MFA enabled you are prompted
-for a second OTP after the one for the main gem. If the alias build or push
-fails, the task warns and continues — the main release is never rolled back.
+From 1.21.0 onward, `rake release` publishes `cypress-on-rails` first, then builds
+and pushes the alias; earlier versions publish the main gem alone. The alias is a
+second `gem push`, so with MFA enabled you are prompted for a second OTP after
+the one for the main gem. If the alias build or push fails, the task warns and
+continues — the main release is never rolled back.
 Retry the alias on its own with:
 
 ```bash
@@ -44,13 +45,15 @@ root raises a descriptive error instead of packaging the wrong files.
 
 `e2e_on_rails` has never been published, and its first publish happens as part of
 the 1.21.0 release — the same release the README points at. Nothing is pushed
-ahead of that: the alias is always built at the release version, so the first
-published alias is 1.21.0.
+ahead of that: `rake release` skips the alias entirely for versions below 1.21.0,
+so a 1.20.x hotfix cut from `master` publishes `cypress-on-rails` on its own.
+Prereleases of the first version do publish the alias — 1.21.0.rc.0 counts as
+1.21.0 for this check — so it can be exercised before the final release.
 
 The push itself is not blocked technically; a first `gem push` creates the gem
 and makes the pusher its owner. It needs a human in the loop for three reasons:
 
-- ADR-0001 requires re-checking on rubygems.org that the name is still unclaimed
+- ADR-0001 requires re-checking on rubygems.org that the name is still available
   immediately before the first publish. That check needs a human.
 - Whoever pushes first becomes the sole owner, so ownership should be set on
   purpose and co-maintainers added right away, not left to whoever runs the
@@ -61,9 +64,18 @@ and makes the pusher its owner. It needs a human in the loop for three reasons:
 
 Steps, during the 1.21.0 release:
 
-1. Before releasing, re-verify the name is still unclaimed: `gem owner e2e_on_rails`
-   should report that the gem does not exist. If someone else has claimed it,
-   stop and revisit ADR-0001 before releasing.
+1. Before releasing, re-verify the name is still available:
+
+   ```bash
+   gem search --remote --exact e2e_on_rails   # no output means the name is free
+   ```
+
+   RubyGems has no "unclaimed" state: a name that returns no result is simply
+   unregistered, and the first successful push registers it. Use the search
+   rather than `gem owner`, which manages maintainers of a gem that already
+   exists and needs credentials. If the search returns a gem, someone else has
+   registered the name: stop and revisit ADR-0001 before releasing.
+
 2. Run `bundle exec rake release` as usual. It publishes `cypress-on-rails 1.21.0`
    first, then builds and pushes `e2e_on_rails 1.21.0`. With MFA you are prompted
    for a second OTP for that push.

--- a/alias_gem/README.md
+++ b/alias_gem/README.md
@@ -1,9 +1,8 @@
 # e2e_on_rails
 
-A thin alias gem with no code of its own. It depends on
-[`cypress-on-rails`](https://github.com/shakacode/cypress-playwright-on-rails)
-at the matching version, and `require "e2e_on_rails"` simply requires
-`cypress_on_rails`.
+A thin alias gem with no code of its own. It depends on exactly the same version
+of [`cypress-on-rails`](https://github.com/shakacode/cypress-playwright-on-rails),
+and `require "e2e_on_rails"` simply requires that gem.
 
 It exists to reserve this project's future canonical name. The project is
 rebranding to **E2E on Rails** (https://e2eonrails.com); at 2.0 `e2e_on_rails`

--- a/alias_gem/README.md
+++ b/alias_gem/README.md
@@ -1,0 +1,15 @@
+# e2e_on_rails
+
+A thin alias gem with no code of its own. It depends on
+[`cypress-on-rails`](https://github.com/shakacode/cypress-playwright-on-rails)
+at the matching version, and `require "e2e_on_rails"` simply requires
+`cypress_on_rails`.
+
+It exists to reserve this project's future canonical name. The project is
+rebranding to **E2E on Rails** (https://e2eonrails.com); at 2.0 `e2e_on_rails`
+becomes the real gem and `cypress-on-rails` becomes the compatibility shim.
+Rationale: `docs/adr/0001-reserve-e2e_on_rails-rename-at-2.0.md` and
+`docs/adr/0002-public-rebrand-e2e-on-rails.md`.
+
+Until 2.0, use `cypress-on-rails` directly if you are unsure — that is still
+the documented install path.

--- a/alias_gem/e2e_on_rails.gemspec
+++ b/alias_gem/e2e_on_rails.gemspec
@@ -4,8 +4,9 @@
 # project adopts at 2.0. See ../docs/adr/0001-reserve-e2e_on_rails-rename-at-2.0.md
 # and ../docs/adr/0002-public-rebrand-e2e-on-rails.md.
 #
-# The version and the dependency requirement are both derived from the parent
-# gem's lib/cypress_on_rails/version.rb so the two gems can never drift.
+# The version is read from the parent gem's lib/cypress_on_rails/version.rb and the
+# dependency is pinned to that exact version, so the two gems can never drift and a
+# prerelease alias always resolves the matching prerelease parent.
 alias_gem_root = __dir__
 
 # RubyGems resolves `spec.files` against the current directory, not against the
@@ -23,7 +24,6 @@ parent_version_match = File.read(parent_version_file).match(/VERSION\s*=\s*["'](
 raise "Unable to read CypressOnRails::VERSION from #{parent_version_file}" unless parent_version_match
 
 parent_version = parent_version_match[1]
-parent_major, parent_minor = parent_version.split(".")
 repo_uri = "https://github.com/shakacode/cypress-playwright-on-rails"
 adr_uri = "#{repo_uri}/blob/master/docs/adr/0001-reserve-e2e_on_rails-rename-at-2.0.md"
 
@@ -37,8 +37,8 @@ Gem::Specification.new do |spec|
   spec.summary     = "E2E on Rails: the Rails test bridge for Cypress and Playwright " \
                      "(alias gem; canonical at 2.0)"
   spec.description = "Alias gem that reserves e2e_on_rails, the canonical name this project adopts " \
-                     "at 2.0, and installs the matching cypress-on-rails version. It ships no code " \
-                     "of its own: require 'e2e_on_rails' simply requires 'cypress_on_rails'. Use " \
+                     "at 2.0, and installs exactly the same cypress-on-rails version. It ships no " \
+                     "code of its own: require 'e2e_on_rails' simply requires 'cypress-on-rails'. Use " \
                      "cypress-on-rails directly if you are unsure. Rationale: ADR-0001, #{adr_uri}"
 
   # This directory's own files only; never glob the parent repository.
@@ -53,5 +53,5 @@ Gem::Specification.new do |spec|
     "source_code_uri"   => repo_uri
   }
 
-  spec.add_dependency "cypress-on-rails", "~> #{parent_major}.#{parent_minor}"
+  spec.add_dependency "cypress-on-rails", "= #{parent_version}"
 end

--- a/alias_gem/e2e_on_rails.gemspec
+++ b/alias_gem/e2e_on_rails.gemspec
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Thin wrapper gem that reserves `e2e_on_rails`, the canonical gem name this
+# project adopts at 2.0. See ../docs/adr/0001-reserve-e2e_on_rails-rename-at-2.0.md
+# and ../docs/adr/0002-public-rebrand-e2e-on-rails.md.
+#
+# The version and the dependency requirement are both derived from the parent
+# gem's lib/cypress_on_rails/version.rb so the two gems can never drift.
+alias_gem_root = __dir__
+
+# RubyGems resolves `spec.files` against the current directory, not against the
+# gemspec's directory. Building from the repository root would therefore package
+# the parent repository's README.md instead of this one, so fail loudly instead.
+unless File.identical?(Dir.pwd, alias_gem_root)
+  raise "Build this gem from its own directory: " \
+        "(cd #{File.basename(alias_gem_root)} && gem build e2e_on_rails.gemspec). " \
+        "RubyGems resolves spec.files relative to the current directory " \
+        "(#{Dir.pwd}), which would package the wrong files."
+end
+
+parent_version_file = File.expand_path("../lib/cypress_on_rails/version.rb", alias_gem_root)
+parent_version_match = File.read(parent_version_file).match(/VERSION\s*=\s*["']([^"']+)["']/)
+raise "Unable to read CypressOnRails::VERSION from #{parent_version_file}" unless parent_version_match
+
+parent_version = parent_version_match[1]
+parent_major, parent_minor = parent_version.split(".")
+repo_uri = "https://github.com/shakacode/cypress-playwright-on-rails"
+adr_uri = "#{repo_uri}/blob/master/docs/adr/0001-reserve-e2e_on_rails-rename-at-2.0.md"
+
+Gem::Specification.new do |spec|
+  spec.name        = "e2e_on_rails"
+  spec.version     = parent_version
+  spec.authors     = ["miceportal team", "Grant Petersen-Speelman"]
+  spec.email       = ["info@miceportal.de", "grantspeelman@gmail.com"]
+  spec.license     = "MIT"
+  spec.homepage    = "https://e2eonrails.com"
+  spec.summary     = "E2E on Rails: the Rails test bridge for Cypress and Playwright " \
+                     "(alias gem; canonical at 2.0)"
+  spec.description = "Alias gem that reserves e2e_on_rails, the canonical name this project adopts " \
+                     "at 2.0, and installs the matching cypress-on-rails version. It ships no code " \
+                     "of its own: require 'e2e_on_rails' simply requires 'cypress_on_rails'. Use " \
+                     "cypress-on-rails directly if you are unsure. Rationale: ADR-0001, #{adr_uri}"
+
+  # This directory's own files only; never glob the parent repository.
+  spec.files = Dir["lib/**/*.rb"].sort + ["README.md"]
+  spec.require_paths = ["lib"]
+
+  spec.metadata = {
+    "bug_tracker_uri"   => "#{repo_uri}/issues",
+    "changelog_uri"     => "#{repo_uri}/blob/master/CHANGELOG.md",
+    "documentation_uri" => "https://e2eonrails.com",
+    "homepage_uri"      => "https://e2eonrails.com",
+    "source_code_uri"   => repo_uri
+  }
+
+  spec.add_dependency "cypress-on-rails", "~> #{parent_major}.#{parent_minor}"
+end

--- a/alias_gem/lib/e2e_on_rails.rb
+++ b/alias_gem/lib/e2e_on_rails.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# The parent gem's entry point is lib/cypress-on-rails.rb (dashed); there is no
+# lib/cypress_on_rails.rb, so requiring the underscored name would raise LoadError.
+require 'cypress-on-rails'

--- a/cypress-on-rails.gemspec
+++ b/cypress-on-rails.gemspec
@@ -11,7 +11,9 @@ Gem::Specification.new do |s|
   s.summary     = "Integrates Cypress and Playwright with Rails or Rack applications"
   s.description = "Integrates Cypress and Playwright with Rails or Rack applications"
   s.post_install_message = 'The CypressDev constant is being deprecated and will be completely removed and replaced with CypressOnRails.'
-  s.files         = `git ls-files`.split("\n")
+  # alias_gem/ is the separate e2e_on_rails wrapper gem (ADR-0001); it must not
+  # be packaged into this gem.
+  s.files         = `git ls-files`.split("\n").reject { |file| file.start_with?("alias_gem/") }
   s.test_files    = `git ls-files -- {spec}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -475,6 +475,9 @@ end
 # Builds and pushes the alias gem after the main gem is published. The alias is
 # a convenience, so any failure here warns and returns instead of aborting: the
 # main release has already happened and must never be rolled back.
+#
+# Dry runs build the alias too, so a broken alias gemspec surfaces before a live
+# release; they never push. The built artifact is always removed.
 # Returns :dry_run, :published, :skipped, or :failed.
 def publish_alias_gem(release_root:, gem_version:, dry_run:)
   alias_dir = File.join(release_root, ALIAS_GEM_DIR_NAME)
@@ -486,22 +489,25 @@ def publish_alias_gem(release_root:, gem_version:, dry_run:)
     return :skipped
   end
 
-  if dry_run
-    puts "DRY RUN: Would build and push #{ALIAS_GEM_NAME} #{gem_version} (alias gem, same version as #{MAIN_GEM_NAME})."
-    puts "DRY RUN: Would run: #{alias_gem_manual_publish_command(gem_version)}"
-    return :dry_run
-  end
-
   begin
     # The alias gemspec must be built from its own directory: RubyGems resolves
-    # spec.files relative to the current directory.
+    # spec.files relative to the current directory. Building is offline, so dry
+    # runs do it too and catch a broken gemspec before a live release.
     sh_in_dir_for_release(alias_dir, "gem build #{Shellwords.escape(gemspec_file)}")
+
+    if dry_run
+      puts "DRY RUN: Built #{package_file} to verify the alias gemspec; not pushing."
+      puts "DRY RUN: Would run: #{alias_gem_manual_publish_command(gem_version)}"
+      return :dry_run
+    end
+
+    puts "Carefully add your OTP for RubyGems again. The alias gem is a second push, so MFA prompts once more."
     sh_in_dir_for_release(alias_dir, "gem push #{Shellwords.escape(package_file)}")
     puts "Published #{ALIAS_GEM_NAME} #{gem_version} to RubyGems."
     :published
   rescue StandardError => error
-    warn "WARNING: Failed to publish the #{ALIAS_GEM_NAME} alias gem #{gem_version}: #{error.message}"
-    warn "WARNING: #{MAIN_GEM_NAME} #{gem_version} is already published and is unaffected."
+    warn "WARNING: Failed to #{dry_run ? 'build' : 'publish'} the #{ALIAS_GEM_NAME} alias gem #{gem_version}: #{error.message}"
+    warn "WARNING: #{MAIN_GEM_NAME} #{gem_version} is #{dry_run ? 'unaffected' : 'already published and is unaffected'}."
     warn "WARNING: Retry the alias gem manually with: #{alias_gem_manual_publish_command(gem_version)}"
     :failed
   ensure
@@ -525,10 +531,13 @@ def print_release_summary(release_result)
     release_result.fetch(:staged_files, []).each { |file| puts "  - #{file}" }
     puts "Gems that would be published:"
     puts "  - #{MAIN_GEM_NAME} #{released_version}"
-    if alias_gem_status == :skipped
+    case alias_gem_status
+    when :skipped
       puts "  - #{ALIAS_GEM_NAME} #{released_version} (SKIPPED: #{ALIAS_GEM_DIR_NAME}/#{ALIAS_GEM_NAME}.gemspec not found)"
+    when :failed
+      puts "  - #{ALIAS_GEM_NAME} #{released_version} (alias gem, FAILED TO BUILD: fix #{ALIAS_GEM_DIR_NAME}/#{ALIAS_GEM_NAME}.gemspec before releasing)"
     else
-      puts "  - #{ALIAS_GEM_NAME} #{released_version} (alias gem)"
+      puts "  - #{ALIAS_GEM_NAME} #{released_version} (alias gem, built and verified, not pushed)"
     end
     puts "Changelog: #{changelog_section_found ? 'CHANGELOG.md section found' : 'No CHANGELOG.md section found'}"
     puts "To actually release, run: bundle exec rake \"release[#{released_version}]\""

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -2,6 +2,7 @@
 
 require "bundler"
 require "English"
+require "fileutils"
 require "open3"
 require "rubygems/version"
 require "shellwords"
@@ -9,6 +10,12 @@ require "tempfile"
 require "tmpdir"
 
 GITHUB_REPO_SLUG_PATTERN = /\A[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\z/ unless defined?(GITHUB_REPO_SLUG_PATTERN)
+
+# The repository publishes two gems at the same version: the real gem, and the
+# `e2e_on_rails` alias that reserves the canonical name adopted at 2.0 (ADR-0001).
+MAIN_GEM_NAME = "cypress-on-rails" unless defined?(MAIN_GEM_NAME)
+ALIAS_GEM_NAME = "e2e_on_rails" unless defined?(ALIAS_GEM_NAME)
+ALIAS_GEM_DIR_NAME = "alias_gem" unless defined?(ALIAS_GEM_DIR_NAME)
 
 def release_truthy?(value)
   [true, "true", "yes", 1, "1", "t"].include?(value.instance_of?(String) ? value.downcase : value)
@@ -456,10 +463,57 @@ def release_staged_files
   ]
 end
 
+def alias_gem_package_file(gem_version)
+  "#{ALIAS_GEM_NAME}-#{gem_version}.gem"
+end
+
+def alias_gem_manual_publish_command(gem_version)
+  "(cd #{ALIAS_GEM_DIR_NAME} && gem build #{ALIAS_GEM_NAME}.gemspec && " \
+    "gem push #{alias_gem_package_file(gem_version)})"
+end
+
+# Builds and pushes the alias gem after the main gem is published. The alias is
+# a convenience, so any failure here warns and returns instead of aborting: the
+# main release has already happened and must never be rolled back.
+# Returns :dry_run, :published, :skipped, or :failed.
+def publish_alias_gem(release_root:, gem_version:, dry_run:)
+  alias_dir = File.join(release_root, ALIAS_GEM_DIR_NAME)
+  gemspec_file = "#{ALIAS_GEM_NAME}.gemspec"
+  package_file = alias_gem_package_file(gem_version)
+
+  unless File.exist?(File.join(alias_dir, gemspec_file))
+    puts "Skipping #{ALIAS_GEM_NAME}: #{ALIAS_GEM_DIR_NAME}/#{gemspec_file} not found in #{release_root}."
+    return :skipped
+  end
+
+  if dry_run
+    puts "DRY RUN: Would build and push #{ALIAS_GEM_NAME} #{gem_version} (alias gem, same version as #{MAIN_GEM_NAME})."
+    puts "DRY RUN: Would run: #{alias_gem_manual_publish_command(gem_version)}"
+    return :dry_run
+  end
+
+  begin
+    # The alias gemspec must be built from its own directory: RubyGems resolves
+    # spec.files relative to the current directory.
+    sh_in_dir_for_release(alias_dir, "gem build #{Shellwords.escape(gemspec_file)}")
+    sh_in_dir_for_release(alias_dir, "gem push #{Shellwords.escape(package_file)}")
+    puts "Published #{ALIAS_GEM_NAME} #{gem_version} to RubyGems."
+    :published
+  rescue StandardError => error
+    warn "WARNING: Failed to publish the #{ALIAS_GEM_NAME} alias gem #{gem_version}: #{error.message}"
+    warn "WARNING: #{MAIN_GEM_NAME} #{gem_version} is already published and is unaffected."
+    warn "WARNING: Retry the alias gem manually with: #{alias_gem_manual_publish_command(gem_version)}"
+    :failed
+  ensure
+    FileUtils.rm_f(File.join(alias_dir, package_file))
+  end
+end
+
 def print_release_summary(release_result)
   released_version = release_result[:released_gem_version]
   dry_run = release_result[:dry_run]
   changelog_section_found = release_result[:changelog_section_found]
+  alias_gem_status = release_result[:alias_gem_status]
 
   puts "\n#{'=' * 80}"
   puts(dry_run ? "DRY RUN COMPLETE" : "RELEASE COMPLETE")
@@ -469,10 +523,25 @@ def print_release_summary(release_result)
     puts "Version would be bumped to: #{released_version}"
     puts "Files that would be updated:"
     release_result.fetch(:staged_files, []).each { |file| puts "  - #{file}" }
+    puts "Gems that would be published:"
+    puts "  - #{MAIN_GEM_NAME} #{released_version}"
+    if alias_gem_status == :skipped
+      puts "  - #{ALIAS_GEM_NAME} #{released_version} (SKIPPED: #{ALIAS_GEM_DIR_NAME}/#{ALIAS_GEM_NAME}.gemspec not found)"
+    else
+      puts "  - #{ALIAS_GEM_NAME} #{released_version} (alias gem)"
+    end
     puts "Changelog: #{changelog_section_found ? 'CHANGELOG.md section found' : 'No CHANGELOG.md section found'}"
     puts "To actually release, run: bundle exec rake \"release[#{released_version}]\""
   else
-    puts "Published cypress-on-rails #{released_version} to RubyGems."
+    puts "Published #{MAIN_GEM_NAME} #{released_version} to RubyGems."
+    case alias_gem_status
+    when :published
+      puts "Published #{ALIAS_GEM_NAME} #{released_version} to RubyGems."
+    when :failed
+      puts "WARNING: #{ALIAS_GEM_NAME} #{released_version} was NOT published. Retry with: #{alias_gem_manual_publish_command(released_version)}"
+    else
+      puts "#{ALIAS_GEM_NAME} was not published (#{ALIAS_GEM_DIR_NAME}/#{ALIAS_GEM_NAME}.gemspec not found)."
+    end
     puts(changelog_section_found ? "GitHub release synced from CHANGELOG.md." : "GitHub release not synced because CHANGELOG.md section was missing.")
   end
 end
@@ -482,6 +551,7 @@ def perform_release(gem_version:, dry_run:, check_uncommitted: true, allow_versi
   gem_root = File.expand_path("..", __dir__)
   released_gem_version = nil
   changelog_section_found = false
+  alias_gem_status = :skipped
   staged_files = release_staged_files
 
   verify_gh_auth(gem_root: gem_root) unless dry_run
@@ -520,9 +590,9 @@ def perform_release(gem_version:, dry_run:, check_uncommitted: true, allow_versi
 
     if dry_run
       if version_already_current
-        puts "DRY RUN: Would tag v#{actual_version}, push, and release gem from the current commit."
+        puts "DRY RUN: Would tag v#{actual_version}, push, and release #{MAIN_GEM_NAME} #{actual_version} from the current commit."
       else
-        puts "DRY RUN: Would commit #{staged_files.join(', ')}, tag v#{actual_version}, push, and release gem."
+        puts "DRY RUN: Would commit #{staged_files.join(', ')}, tag v#{actual_version}, push, and release #{MAIN_GEM_NAME} #{actual_version}."
       end
     else
       unless version_already_current
@@ -534,6 +604,12 @@ def perform_release(gem_version:, dry_run:, check_uncommitted: true, allow_versi
       puts "Carefully add your OTP for RubyGems. If you get an error, run 'gem release' again."
       sh_in_dir_for_release(release_root, "gem release")
     end
+
+    alias_gem_status = publish_alias_gem(
+      release_root: release_root,
+      gem_version: actual_version,
+      dry_run: dry_run
+    )
   end
 
   if released_gem_version
@@ -555,6 +631,7 @@ def perform_release(gem_version:, dry_run:, check_uncommitted: true, allow_versi
     dry_run: dry_run,
     released_gem_version: released_gem_version,
     changelog_section_found: changelog_section_found,
+    alias_gem_status: alias_gem_status,
     staged_files: staged_files
   }
 end
@@ -572,6 +649,10 @@ def perform_sync_github_release(gem_root:, version_input:, dry_run:)
 end
 
 desc("Releases the gem using the given version.
+
+Publishes two gems at the same version: cypress-on-rails, then the e2e_on_rails
+alias gem from alias_gem/. An alias-gem failure warns and continues; the main
+release is never rolled back.
 
 Recommended flow:
   1. Run /update-changelog release, /update-changelog rc, or an explicit version.

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -16,6 +16,12 @@ GITHUB_REPO_SLUG_PATTERN = /\A[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\z/ unless defined
 MAIN_GEM_NAME = "cypress-on-rails" unless defined?(MAIN_GEM_NAME)
 ALIAS_GEM_NAME = "e2e_on_rails" unless defined?(ALIAS_GEM_NAME)
 ALIAS_GEM_DIR_NAME = "alias_gem" unless defined?(ALIAS_GEM_DIR_NAME)
+# The alias gem does not exist on RubyGems before this version. ADR-0001 puts a
+# human name/ownership check on its first publish, and that check happens during
+# the 1.21.0 release, so an earlier release line (a 1.20.x hotfix, say) must not
+# create the gem as a side effect. Prereleases of this version do publish, so the
+# alias can be exercised before a final release: 1.21.0.rc.0 compares as 1.21.0.
+ALIAS_GEM_FIRST_VERSION = "1.21.0" unless defined?(ALIAS_GEM_FIRST_VERSION)
 
 def release_truthy?(value)
   [true, "true", "yes", 1, "1", "t"].include?(value.instance_of?(String) ? value.downcase : value)
@@ -478,11 +484,18 @@ end
 #
 # Dry runs build the alias too, so a broken alias gemspec surfaces before a live
 # release; they never push. The built artifact is always removed.
-# Returns :dry_run, :published, :skipped, or :failed.
+# Releases before ALIAS_GEM_FIRST_VERSION do not publish the alias at all.
+# Returns :dry_run, :published, :below_first_version, :skipped, or :failed.
 def publish_alias_gem(release_root:, gem_version:, dry_run:)
   alias_dir = File.join(release_root, ALIAS_GEM_DIR_NAME)
   gemspec_file = "#{ALIAS_GEM_NAME}.gemspec"
   package_file = alias_gem_package_file(gem_version)
+
+  if Gem::Version.new(gem_version).release < Gem::Version.new(ALIAS_GEM_FIRST_VERSION)
+    puts "Skipping #{ALIAS_GEM_NAME}: the alias gem is first published at " \
+         "#{ALIAS_GEM_FIRST_VERSION}, and this release is #{gem_version}."
+    return :below_first_version
+  end
 
   unless File.exist?(File.join(alias_dir, gemspec_file))
     warn "WARNING: Skipping #{ALIAS_GEM_NAME}: #{ALIAS_GEM_DIR_NAME}/#{gemspec_file} not found in #{release_root}."
@@ -538,6 +551,8 @@ def print_release_summary(release_result)
     puts "Gems that would be published:"
     puts "  - #{MAIN_GEM_NAME} #{released_version}"
     case alias_gem_status
+    when :below_first_version
+      puts "  - #{ALIAS_GEM_NAME}: not published, the alias gem starts at #{ALIAS_GEM_FIRST_VERSION}"
     when :skipped
       puts "  - #{ALIAS_GEM_NAME} #{released_version} (SKIPPED: #{ALIAS_GEM_DIR_NAME}/#{ALIAS_GEM_NAME}.gemspec not found)"
     when :failed
@@ -554,6 +569,8 @@ def print_release_summary(release_result)
       puts "Published #{ALIAS_GEM_NAME} #{released_version} to RubyGems."
     when :failed
       puts "WARNING: #{ALIAS_GEM_NAME} #{released_version} was NOT published. Retry with: #{alias_gem_manual_publish_command(released_version)}"
+    when :below_first_version
+      puts "#{ALIAS_GEM_NAME} was not published: the alias gem starts at #{ALIAS_GEM_FIRST_VERSION}."
     else
       puts "WARNING: #{ALIAS_GEM_NAME} #{released_version} was NOT published " \
            "(#{ALIAS_GEM_DIR_NAME}/#{ALIAS_GEM_NAME}.gemspec not found)."

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -485,9 +485,14 @@ def publish_alias_gem(release_root:, gem_version:, dry_run:)
   package_file = alias_gem_package_file(gem_version)
 
   unless File.exist?(File.join(alias_dir, gemspec_file))
-    puts "Skipping #{ALIAS_GEM_NAME}: #{ALIAS_GEM_DIR_NAME}/#{gemspec_file} not found in #{release_root}."
+    warn "WARNING: Skipping #{ALIAS_GEM_NAME}: #{ALIAS_GEM_DIR_NAME}/#{gemspec_file} not found in #{release_root}."
+    warn "WARNING: The #{ALIAS_GEM_NAME} alias gem was NOT built or published; restore the gemspec and publish it manually."
     return :skipped
   end
+
+  # Tracks which step raised so the warning names the phase that actually
+  # failed: `gem build` runs unconditionally and can fail in a live release too.
+  stage = :build
 
   begin
     # The alias gemspec must be built from its own directory: RubyGems resolves
@@ -501,12 +506,13 @@ def publish_alias_gem(release_root:, gem_version:, dry_run:)
       return :dry_run
     end
 
+    stage = :publish
     puts "Carefully add your OTP for RubyGems again. The alias gem is a second push, so MFA prompts once more."
     sh_in_dir_for_release(alias_dir, "gem push #{Shellwords.escape(package_file)}")
     puts "Published #{ALIAS_GEM_NAME} #{gem_version} to RubyGems."
     :published
   rescue StandardError => error
-    warn "WARNING: Failed to #{dry_run ? 'build' : 'publish'} the #{ALIAS_GEM_NAME} alias gem #{gem_version}: #{error.message}"
+    warn "WARNING: Failed to #{stage} the #{ALIAS_GEM_NAME} alias gem #{gem_version}: #{error.message}"
     warn "WARNING: #{MAIN_GEM_NAME} #{gem_version} is #{dry_run ? 'unaffected' : 'already published and is unaffected'}."
     warn "WARNING: Retry the alias gem manually with: #{alias_gem_manual_publish_command(gem_version)}"
     :failed
@@ -549,7 +555,8 @@ def print_release_summary(release_result)
     when :failed
       puts "WARNING: #{ALIAS_GEM_NAME} #{released_version} was NOT published. Retry with: #{alias_gem_manual_publish_command(released_version)}"
     else
-      puts "#{ALIAS_GEM_NAME} was not published (#{ALIAS_GEM_DIR_NAME}/#{ALIAS_GEM_NAME}.gemspec not found)."
+      puts "WARNING: #{ALIAS_GEM_NAME} #{released_version} was NOT published " \
+           "(#{ALIAS_GEM_DIR_NAME}/#{ALIAS_GEM_NAME}.gemspec not found)."
     end
     puts(changelog_section_found ? "GitHub release synced from CHANGELOG.md." : "GitHub release not synced because CHANGELOG.md section was missing.")
   end

--- a/spec/cypress_on_rails/release_rake_spec.rb
+++ b/spec/cypress_on_rails/release_rake_spec.rb
@@ -137,6 +137,22 @@ RSpec.describe "release rake helpers" do
     end
   end
 
+  describe "alias gemspec" do
+    let(:gem_root) { File.expand_path("../..", __dir__) }
+
+    it "pins cypress-on-rails to the exact parent version" do
+      spec = Dir.chdir(File.join(gem_root, "alias_gem")) do
+        Gem::Specification.load("e2e_on_rails.gemspec")
+      end
+      dependency = spec.dependencies.find { |dep| dep.name == "cypress-on-rails" }
+
+      # An exact pin, not "~>": a prerelease alias must resolve the matching
+      # prerelease parent, and must never resolve a different minor line.
+      expect(spec.version.to_s).to eq(current_gem_version(gem_root))
+      expect(dependency.requirement.to_s).to eq("= #{current_gem_version(gem_root)}")
+    end
+  end
+
   describe "alias gem publishing" do
     def with_alias_gem_release_root
       Dir.mktmpdir do |dir|

--- a/spec/cypress_on_rails/release_rake_spec.rb
+++ b/spec/cypress_on_rails/release_rake_spec.rb
@@ -137,6 +137,77 @@ RSpec.describe "release rake helpers" do
     end
   end
 
+  describe "alias gem publishing" do
+    def with_alias_gem_release_root
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "alias_gem"))
+        File.write(File.join(dir, "alias_gem", "e2e_on_rails.gemspec"), "# fixture\n")
+        yield dir
+      end
+    end
+
+    def stub_release_flow(release_root, dry_run:)
+      allow(self).to receive(:ensure_clean_worktree!)
+      allow(self).to receive(:verify_gh_auth)
+      allow(self).to receive(:with_release_checkout)
+        .with(gem_root: File.expand_path("../..", __dir__), dry_run: dry_run)
+        .and_yield(release_root)
+      allow(self).to receive(:current_gem_version).with(release_root).and_return("1.21.0")
+      allow(self).to receive(:warn_changelog_missing)
+      allow(self).to receive(:validate_release_version_policy!)
+      allow(self).to receive(:sync_github_release_after_publish)
+    end
+
+    it "reports both gems in a dry run without pushing either" do
+      with_alias_gem_release_root do |release_root|
+        events = []
+        stub_release_flow(release_root, dry_run: true)
+        allow(self).to receive(:sh_in_dir_for_release) { |_dir, command| events << command }
+
+        result = nil
+        output = capture_stdout do
+          result = perform_release(gem_version: "1.21.0", dry_run: true)
+          print_release_summary(result)
+        end
+
+        expect(result[:alias_gem_status]).to eq(:dry_run)
+        expect(output).to include("DRY RUN: Would build and push e2e_on_rails 1.21.0")
+        expect(output).to include("  - cypress-on-rails 1.21.0")
+        expect(output).to include("  - e2e_on_rails 1.21.0 (alias gem)")
+        expect(events.grep(/gem push/)).to be_empty
+        expect(events.grep(/gem release/)).to be_empty
+      end
+    end
+
+    it "warns and continues when the alias gem push fails after the main release" do
+      with_alias_gem_release_root do |release_root|
+        events = []
+        stub_release_flow(release_root, dry_run: false)
+        allow(self).to receive(:sh_in_dir_for_release) do |_dir, command|
+          events << command
+          raise "Command failed with status (1): [gem push]" if command.start_with?("gem push")
+        end
+
+        result = nil
+        output = nil
+        expect do
+          output = capture_stdout do
+            result = perform_release(gem_version: "1.21.0", dry_run: false)
+            print_release_summary(result)
+          end
+        end.to output(/WARNING: Failed to publish the e2e_on_rails alias gem 1\.21\.0/).to_stderr
+
+        expect(result[:released_gem_version]).to eq("1.21.0")
+        expect(result[:alias_gem_status]).to eq(:failed)
+        expect(events).to include("gem release")
+        expect(events).to include("gem build e2e_on_rails.gemspec")
+        expect(events).to include("gem push e2e_on_rails-1.21.0.gem")
+        expect(output).to include("Published cypress-on-rails 1.21.0 to RubyGems.")
+        expect(output).to include("WARNING: e2e_on_rails 1.21.0 was NOT published")
+      end
+    end
+  end
+
   describe "#resolve_version_input" do
     it "uses the changelog version when it is newer than the current gem version" do
       allow(self).to receive(:extract_latest_changelog_version).with(gem_root: "/repo").and_return("1.21.0.rc.0")

--- a/spec/cypress_on_rails/release_rake_spec.rb
+++ b/spec/cypress_on_rails/release_rake_spec.rb
@@ -187,9 +187,12 @@ RSpec.describe "release rake helpers" do
         end
 
         expect(result[:alias_gem_status]).to eq(:dry_run)
-        expect(output).to include("DRY RUN: Would build and push e2e_on_rails 1.21.0")
+        expect(output).to include("DRY RUN: Built e2e_on_rails-1.21.0.gem to verify the alias gemspec; not pushing.")
         expect(output).to include("  - cypress-on-rails 1.21.0")
-        expect(output).to include("  - e2e_on_rails 1.21.0 (alias gem)")
+        expect(output).to include("  - e2e_on_rails 1.21.0 (alias gem, built and verified, not pushed)")
+        # The alias is really built in a dry run so a broken gemspec surfaces early,
+        # but nothing is ever pushed.
+        expect(events).to include("gem build e2e_on_rails.gemspec")
         expect(events.grep(/gem push/)).to be_empty
         expect(events.grep(/gem release/)).to be_empty
       end
@@ -199,6 +202,9 @@ RSpec.describe "release rake helpers" do
       with_alias_gem_release_root do |release_root|
         events = []
         stub_release_flow(release_root, dry_run: false)
+        # The release must carry on past the alias failure: the GitHub release
+        # sync happens after the alias step and must still run.
+        expect(self).to receive(:sync_github_release_after_publish)
         allow(self).to receive(:sh_in_dir_for_release) do |_dir, command|
           events << command
           raise "Command failed with status (1): [gem push]" if command.start_with?("gem push")
@@ -215,9 +221,10 @@ RSpec.describe "release rake helpers" do
 
         expect(result[:released_gem_version]).to eq("1.21.0")
         expect(result[:alias_gem_status]).to eq(:failed)
-        expect(events).to include("gem release")
-        expect(events).to include("gem build e2e_on_rails.gemspec")
-        expect(events).to include("gem push e2e_on_rails-1.21.0.gem")
+        # The main gem is published before the alias is built, and built before pushed.
+        expect(events.index("gem release")).to be < events.index("gem build e2e_on_rails.gemspec")
+        expect(events.index("gem build e2e_on_rails.gemspec"))
+          .to be < events.index("gem push e2e_on_rails-1.21.0.gem")
         expect(output).to include("Published cypress-on-rails 1.21.0 to RubyGems.")
         expect(output).to include("WARNING: e2e_on_rails 1.21.0 was NOT published")
       end

--- a/spec/cypress_on_rails/release_rake_spec.rb
+++ b/spec/cypress_on_rails/release_rake_spec.rb
@@ -172,13 +172,13 @@ RSpec.describe "release rake helpers" do
       end
     end
 
-    def stub_release_flow(release_root, dry_run:)
+    def stub_release_flow(release_root, dry_run:, version: "1.21.0")
       allow(self).to receive(:ensure_clean_worktree!)
       allow(self).to receive(:verify_gh_auth)
       allow(self).to receive(:with_release_checkout)
         .with(gem_root: File.expand_path("../..", __dir__), dry_run: dry_run)
         .and_yield(release_root)
-      allow(self).to receive(:current_gem_version).with(release_root).and_return("1.21.0")
+      allow(self).to receive(:current_gem_version).with(release_root).and_return(version)
       allow(self).to receive(:warn_changelog_missing)
       allow(self).to receive(:validate_release_version_policy!)
       allow(self).to receive(:sync_github_release_after_publish)
@@ -257,6 +257,64 @@ RSpec.describe "release rake helpers" do
         end.to output(/WARNING: Failed to build the e2e_on_rails alias gem 1\.21\.0/).to_stderr
 
         expect(result[:alias_gem_status]).to eq(:failed)
+      end
+    end
+
+    it "does not publish the alias gem for a release before 1.21.0" do
+      with_alias_gem_release_root do |release_root|
+        events = []
+        stub_release_flow(release_root, dry_run: false, version: "1.20.2")
+        allow(self).to receive(:sh_in_dir_for_release) { |_dir, command| events << command }
+
+        result = nil
+        output = capture_stdout do
+          result = perform_release(gem_version: "1.20.2", dry_run: false)
+          print_release_summary(result)
+        end
+
+        # A 1.20.x hotfix must not bring e2e_on_rails into existence as a side
+        # effect: its first publish is a deliberate, human-checked step during
+        # the 1.21.0 release (ADR-0001), so nothing is built or pushed here.
+        expect(result[:alias_gem_status]).to eq(:below_first_version)
+        expect(events.grep(/gem build/)).to be_empty
+        expect(events.grep(/gem push/)).to be_empty
+        expect(events).to include("gem release")
+        expect(output).to include("e2e_on_rails was not published: the alias gem starts at 1.21.0.")
+      end
+    end
+
+    it "publishes the alias gem for a prerelease of the first alias version" do
+      with_alias_gem_release_root do |release_root|
+        events = []
+        stub_release_flow(release_root, dry_run: false, version: "1.21.0.rc.0")
+        allow(self).to receive(:sh_in_dir_for_release) { |_dir, command| events << command }
+
+        result = nil
+        capture_stdout { result = perform_release(gem_version: "1.21.0.rc.0", dry_run: false) }
+
+        # The gate compares release segments, so a 1.21.0 prerelease is not
+        # "before 1.21.0": the alias ships with the rc rather than debuting
+        # untested on the final release.
+        expect(result[:alias_gem_status]).to eq(:published)
+        expect(events).to include("gem build e2e_on_rails.gemspec")
+        expect(events).to include("gem push e2e_on_rails-1.21.0.rc.0.gem")
+      end
+    end
+
+    it "reports the version gate in a dry run before 1.21.0" do
+      with_alias_gem_release_root do |release_root|
+        stub_release_flow(release_root, dry_run: true, version: "1.20.2")
+        allow(self).to receive(:sh_in_dir_for_release)
+
+        result = nil
+        output = capture_stdout do
+          result = perform_release(gem_version: "1.20.2", dry_run: true)
+          print_release_summary(result)
+        end
+
+        expect(result[:alias_gem_status]).to eq(:below_first_version)
+        expect(output).to include("  - cypress-on-rails 1.20.2")
+        expect(output).to include("  - e2e_on_rails: not published, the alias gem starts at 1.21.0")
       end
     end
 

--- a/spec/cypress_on_rails/release_rake_spec.rb
+++ b/spec/cypress_on_rails/release_rake_spec.rb
@@ -22,6 +22,16 @@ RSpec.describe "release rake helpers" do
     $stdout = original_stdout
   end
 
+  def capture_stderr
+    original_stderr = $stderr
+    output = StringIO.new
+    $stderr = output
+    yield
+    output.string
+  ensure
+    $stderr = original_stderr
+  end
+
   describe "#parse_release_tag_to_gem_version" do
     it "parses stable and prerelease tags" do
       expect(parse_release_tag_to_gem_version("v1.21.0")).to eq("1.21.0")
@@ -94,7 +104,7 @@ RSpec.describe "release rake helpers" do
       end
 
       result = nil
-      capture_stdout { result = perform_release(gem_version: "", dry_run: false) }
+      capture_stderr { capture_stdout { result = perform_release(gem_version: "", dry_run: false) } }
       bump_command = events.find { |command| command.include?("gem bump") }
 
       expect(result[:released_gem_version]).to eq("1.21.0")
@@ -126,7 +136,7 @@ RSpec.describe "release rake helpers" do
       end
 
       result = nil
-      capture_stdout { result = perform_release(gem_version: "", dry_run: false) }
+      capture_stderr { capture_stdout { result = perform_release(gem_version: "", dry_run: false) } }
 
       expect(result[:released_gem_version]).to eq("1.21.0")
       expect(events.grep(/gem bump/)).to be_empty
@@ -227,6 +237,47 @@ RSpec.describe "release rake helpers" do
           .to be < events.index("gem push e2e_on_rails-1.21.0.gem")
         expect(output).to include("Published cypress-on-rails 1.21.0 to RubyGems.")
         expect(output).to include("WARNING: e2e_on_rails 1.21.0 was NOT published")
+      end
+    end
+
+    it "names the build phase, not publish, when the live-release alias build fails" do
+      with_alias_gem_release_root do |release_root|
+        stub_release_flow(release_root, dry_run: false)
+        # A broken alias gemspec fails at `gem build`, which runs in live releases
+        # too: the warning must not claim the push step was reached.
+        allow(self).to receive(:sh_in_dir_for_release) do |_dir, command|
+          raise "Command failed with status (1): [gem build]" if command.start_with?("gem build")
+        end
+
+        result = nil
+        expect do
+          capture_stdout do
+            result = perform_release(gem_version: "1.21.0", dry_run: false)
+          end
+        end.to output(/WARNING: Failed to build the e2e_on_rails alias gem 1\.21\.0/).to_stderr
+
+        expect(result[:alias_gem_status]).to eq(:failed)
+      end
+    end
+
+    it "warns instead of silently skipping when the alias gemspec is missing" do
+      Dir.mktmpdir do |release_root|
+        stub_release_flow(release_root, dry_run: false)
+        allow(self).to receive(:sh_in_dir_for_release)
+
+        result = nil
+        output = nil
+        expect do
+          output = capture_stdout do
+            result = perform_release(gem_version: "1.21.0", dry_run: false)
+            print_release_summary(result)
+          end
+        end.to output(%r{WARNING: Skipping e2e_on_rails: alias_gem/e2e_on_rails\.gemspec not found}).to_stderr
+
+        expect(result[:alias_gem_status]).to eq(:skipped)
+        expect(output).to include(
+          "WARNING: e2e_on_rails 1.21.0 was NOT published (alias_gem/e2e_on_rails.gemspec not found)."
+        )
       end
     end
   end


### PR DESCRIPTION
## Why

ADR-0001 reserves `e2e_on_rails` as the canonical gem name this project adopts at 2.0, and ADR-0002 brands the project "E2E on Rails" at e2eonrails.com. `playwright-on-rails` was already taken on RubyGems, so the name should be claimed now, while `cypress-on-rails` stays the install name for all of 1.x. Closes #226.

## What changed

- New `alias_gem/` wrapper gem: gemspec, `lib/e2e_on_rails.rb`, and a short README. The version and the `cypress-on-rails ~> MAJOR.MINOR` dependency are both derived from `lib/cypress_on_rails/version.rb`, so the two gems cannot drift and there is no second version to bump.
- `rake release` publishes `cypress-on-rails` first, then builds and pushes the alias at the same version. An alias failure warns with a retry command and continues; the main release is never rolled back. Dry runs report both gems and push neither.
- Two hermetic specs in `spec/cypress_on_rails/release_rake_spec.rb` cover the dry run and the alias-push failure path.
- `cypress-on-rails.gemspec` excludes `alias_gem/` from its `git ls-files` glob so the two packages stay disjoint; `.gitignore` covers built `*.gem` files.
- RELEASING.md documents the two gems and the one-time first publish; README gains one line under Installation.
- The alias requires `cypress-on-rails` (dashed): the parent gem has no `lib/cypress_on_rails.rb`, so the underscored require named in the issue would raise `LoadError`.
- The alias gemspec refuses to build outside `alias_gem/`, because RubyGems resolves `spec.files` against the current directory and building from the repo root silently packaged the parent's README.

## How to review and verify

```bash
bundle exec rake                                  # 101 examples, 0 failures
bundle exec rake "release[,true]"                 # summary lists both gems, pushes nothing
(cd alias_gem && gem build e2e_on_rails.gemspec)
ruby -e 'require "rubygems"; s = Gem::Specification.load("cypress-on-rails.gemspec"); p s.files.grep(%r{^alias_gem/})'   # => []
```

Scratch install proof: install the built `cypress-on-rails-VERSION.gem` with `--ignore-dependencies` into a temp dir, then `GEM_HOME=<tmp> GEM_PATH=<tmp> gem install --local alias_gem/e2e_on_rails-VERSION.gem`, then `GEM_HOME=<tmp> GEM_PATH=<tmp> ruby -e "require 'e2e_on_rails'; puts CypressOnRails::VERSION"` prints the parent version.

## Maintainer step after merge (one time, not done by this PR)

Nothing is published here. Before the next `rake release` can push the alias, claim the name once:

```bash
gem owner e2e_on_rails                       # must report the gem does not exist
(cd alias_gem && gem build e2e_on_rails.gemspec)
gem push alias_gem/e2e_on_rails-VERSION.gem  # RubyGems OTP
rm alias_gem/e2e_on_rails-VERSION.gem
gem owner e2e_on_rails --add EMAIL           # add the other release maintainers
```

<details>
<summary>Agent details</summary>

### Lane Card (PR-open)

Thread: cpor-issue-226-reef; Preference: opus/high; observed: claude-code/conductor/UNKNOWN/UNKNOWN; envelope: coordinator-approved; Batch/lane: cpor-wave1-20260903 / issue-226; Target: https://github.com/shakacode/cypress-playwright-on-rails/issues/226; Canonical launch: shakacode/cypress-playwright-on-rails:issue:226; Ad-hoc override: none; Branch: agent/226-e2e-on-rails-alias-gem; claim: cpor-wave1-maker-226/1/cpor-wave1-226-i1; coordinator: cpor-wave1-coordinator; Path expansion: none.

### Commands and results

| Command | Exit | Result |
|---|---|---|
| `bundle exec rspec spec/cypress_on_rails/release_rake_spec.rb` | 0 | 23 examples, 0 failures |
| `.agents/bin/validate` (worker, then re-run by coordinator at the same head) | 0 | 101 examples, 0 failures |
| `(cd alias_gem && gem build e2e_on_rails.gemspec)` | 0 | packages exactly README.md + lib/e2e_on_rails.rb; dependency `cypress-on-rails ~> 1.20` |
| `gem build cypress-on-rails.gemspec` + `files.grep(%r{^alias_gem/})` | 0 | `[]` |
| scratch install + `require 'e2e_on_rails'` | 0 | prints `1.20.1` |
| `bundle exec rake "release[,true]"` | 0 | dry run lists both gems, no pushes |

### Exact-head and replay evidence

Accepted base `4915b86faf44a21af0c5bd4ed0d66763c0e80c54` (master). Implementation head `95ebe893d3090e6d13aa01b3f09bd6a10b7ce760`; the coordinator's changelog commit made `d1559b6`. Review-fix commits d92c5e3 (exact version pin + gemspec spec), f73a264 (dry run builds the alias, OTP hint, failure spec asserts the continue path), and d5850c1 (RELEASING/README wording) and 84b2c54 (first alias publish tied to the 1.21.0 release in RELEASING.md) bring the head to `84b2c5474b2874992c8dd367b98802e0948b82a5`; `.agents/bin/validate` 102 examples, 0 failures and a real dry run built `e2e_on_rails-1.20.2.gem` inside the temp worktree without pushing. Stage-dependency plan `cpor-wave1-20260903-plan`, gate status eligible, no edges.

### Coordination and reviewer telemetry

Batch `cpor-wave1-20260903` registered with the private coordination backend; claim held by `cpor-wave1-maker-226`. Configured reviewers: CodeRabbit, Claude review workflow, Greptile, plus an independent checker lane and a QA lane owned by the coordinator (evidence appended below when complete).

### Decision log

1. `require 'cypress-on-rails'` instead of the issue's underscored name: the parent entry point is `lib/cypress-on-rails.rb`; the underscored require fails. Possible follow-up: add `lib/cypress_on_rails.rb` so both spellings load.
2. Build guard: the alias gemspec refuses to build outside `alias_gem/` because RubyGems resolves `files` against cwd and the silent failure packaged the parent README.
3. License `MIT` from the root LICENSE; no `required_ruby_version` because the parent declares none.
4. `homepage_uri` and `documentation_uri` both point at e2eonrails.com as the issue specifies; RubyGems only displays the first.
5. `.gitignore` uses `*.gem` so root-built artifacts are covered too.
6. Skip path prints with `puts`, failure path with `warn`, keeping existing release specs' stderr clean.
7. Commit order was rearranged so every intermediate commit builds.
8. Review fix: the alias depends on exactly the mirrored parent version (`= VERSION`) instead of `~> MAJOR.MINOR`, because a `~>` requirement excludes prerelease parents and allows drift to later minors; the checker named the exact pin as the correct policy.
9. Review fix: dry runs now build the alias gem so a broken gemspec surfaces before a live release; an OTP hint precedes the second push; the first-publish rationale in RELEASING.md was corrected (a first push creates the gem; the manual step exists for the ADR-0001 re-check, ownership setup, and because the parent version must already be live).
10. Coordinator decision: `rake release` keeps exit status 0 when only the alias push fails, per the issue's warn-and-continue contract; the summary line reports the alias status.

### Merge confidence

Release-surface change with hermetic specs and a local end-to-end dry run; no network publish. Expect the autonomous-merge gate to require a human risk decision because `rakelib/release.rake` is release tooling.

### QA Evidence
- QA lane: cpor-wave1-qa-226-r3 (delta pass over satisfied r2 at d5850c18c62877a7016740171be937bfba8aa4f1, which superseded r1 at d1559b693b57e9caba2118dbc0ea812160d81129), isolated worktree, private coordination: UNKNOWN (QA lane does not hold a claim)
- Scope checked: RELEASING.md first-publish wording and consistency with README and alias README, suite; PR #251 at 84b2c5474b2874992c8dd367b98802e0948b82a5. Carried from r2 at d5850c1: alias packaging (exactly README.md + lib/e2e_on_rails.rb), exact pin `= 1.20.1` in packaged metadata, prerelease proof (`= 1.21.0.rc.0` satisfied while `~> 1.21.0` is not), parent gem 330 files with 0 `alias_gem/` paths, scratch GEM_HOME install and `require 'e2e_on_rails'` printing 1.20.1, dry run building `e2e_on_rails-1.20.2.gem` in the temp worktree with no push or tag and no leftover artifacts, OTP hint immediately before the alias push
- Tested at: 84b2c5474b2874992c8dd367b98802e0948b82a5
- Automated checks: `.agents/bin/validate` exit 0, 102 examples 0 failures; `git diff --stat d5850c1..HEAD` confirms a RELEASING.md-only delta; r2: `bundle exec rspec spec/cypress_on_rails/release_rake_spec.rb` 24 examples 0 failures
- Manual checks: RELEASING.md read in full, no dangling sentences remain; first publish is tied to the 1.21.0 release; ADR-0001 unclaimed-name re-check retained before releasing; "The alias is never pushed before the main gem" present; manual `gem push` framed as a retry only if the release-task push fails; second OTP prompt documented; README line 119 ("Starting with 1.21.0 the gem is also published as `e2e_on_rails`") and alias README are consistent
- User-visible UI change: no
- Visual evidence: not applicable: no UI
- Interaction change: no
- Interaction evidence: not applicable: no UI
- Visual fix: no
- Negative control: r2: root-directory `gem build alias_gem/e2e_on_rails.gemspec` exits 1 with the guard message and no artifact; `~> 1.21.0` fails to match 1.21.0.rc.0 while the shipped `= 1.21.0.rc.0` matches; r3 delta is docs-only
- Performance evidence: not applicable: release tooling and packaging only
- Findings: none at the final head (the r2 finding, a dangling sentence in RELEASING.md introduced by d5850c1, is fixed by 84b2c54)
- QA required: yes
- QA required rationale: release-surface change (rake release, gemspecs) in a release-affecting batch
- QA lane status: satisfied
- Release-blocking status: clear
- Process-gap disposition: checklist+replay

<!-- qa-evidence v2
required: yes
status: satisfied
head_sha: 84b2c5474b2874992c8dd367b98802e0948b82a5
tested_at: 84b2c5474b2874992c8dd367b98802e0948b82a5
scope: delta over r2 (d5850c1): RELEASING.md first-publish wording and README consistency, suite; packaging, pin, install, dry-run evidence carried from r2
automated_checks: validate 102/0 failures; diff-stat confirms RELEASING.md-only delta; r2 release_rake_spec 24/0
manual_checks: dangling fragment removed; 1.21.0 tie-in, ADR-0001 recheck, alias-never-first, manual-push-as-retry, MFA second OTP all present; README/alias README consistent; r2 packaging, exact pin, prerelease proof, parent exclusion, scratch install, dry run no push
user_visible_ui_change: no
visual_evidence_destination: not_applicable
visual_evidence: not applicable: no UI
paint_check: not applicable: no UI
interaction_change: no
interaction_evidence: not applicable: no UI
visual_fix: no
negative_control: r2 root-dir build exits 1 with guard and no artifact; "~> 1.21.0" fails to match 1.21.0.rc.0 while "= 1.21.0.rc.0" matches; r3 docs-only
performance_impact: not_applicable
performance_evidence: not applicable: release tooling only
findings: none at final head
release_blocking: clear
process_gap_disposition: checklist+replay
-->

### Audit receipts

Pending completed-batch audit.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `e2e_on_rails` alias gem, providing the same functionality as `cypress-on-rails` while reserving the planned 2.0 package name.
  * The alias gem remains version-aligned with `cypress-on-rails` for consistent installations.
  * Releases now publish both package names at the same version.

* **Documentation**
  * Updated installation guidance and the changelog with the new package name.
  * Added release instructions covering publishing, dry runs, initial setup, and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

