### PR TITLE
Configure quiet CodeRabbit lifecycle reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,11 @@
+reviews:
+  profile: chill
+  review_status: false
+  review_progress: false
+  in_progress_fortune: false
+  collapse_walkthrough: true
+  auto_review:
+    enabled: false
+    labels:
+      - coderabbit:first-pass
+      - coderabbit:ready

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,10 +2,12 @@ reviews:
   profile: chill
   review_status: false
   review_progress: false
+  commit_status: false
   in_progress_fortune: false
   collapse_walkthrough: true
   auto_review:
     enabled: false
+    auto_incremental_review: false
     labels:
       - coderabbit:first-pass
       - coderabbit:ready

--- a/.github/workflows/coderabbit-lifecycle-review.yml
+++ b/.github/workflows/coderabbit-lifecycle-review.yml
@@ -1,0 +1,28 @@
+name: CodeRabbit Lifecycle Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  request-review:
+    if: github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add CodeRabbit lifecycle label
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const label = context.payload.action === 'opened'
+              ? 'coderabbit:first-pass'
+              : 'coderabbit:ready';
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: [label]
+            });


### PR DESCRIPTION
## Summary
- trigger CodeRabbit labels only when a PR opens or becomes ready for review
- suppress review status, progress, and fortune noise
- pin the label workflow action and skip fork PRs

## Validation
- .agents/bin/validate
- GitHub Actions security scan: pre-existing findings plus one expected no-policy allowlist finding for the new pinned action

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added automated pull request lifecycle labeling for clearer review status tracking.
  - Added repository review configuration to streamline automated review presentation and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->