### PR TITLE
Disable git background maintenance in changelog spec fixtures

### DIFF
--- a/spec/cypress_on_rails/update_changelog_rake_spec.rb
+++ b/spec/cypress_on_rails/update_changelog_rake_spec.rb
@@ -21,6 +21,11 @@ RSpec.describe "update_changelog rake helpers" do
     run_git!("init", chdir: repo_dir)
     run_git!("config", "user.email", "test@example.com", chdir: repo_dir)
     run_git!("config", "user.name", "Test User", chdir: repo_dir)
+    # `git commit` below can trigger git's background auto-maintenance, which
+    # creates and deletes .git/objects/maintenance.lock while Dir.mktmpdir is
+    # removing the tree -- ENOENT mid-walk, then ENOTEMPTY from rmdir.
+    run_git!("config", "maintenance.auto", "false", chdir: repo_dir)
+    run_git!("config", "gc.auto", "0", chdir: repo_dir)
     File.write(File.join(repo_dir, "README.md"), "test\n")
     run_git!("add", "README.md", chdir: repo_dir)
     run_git!("commit", "-m", "Initial commit", chdir: repo_dir)


### PR DESCRIPTION
Fixes the intermittent `Errno::ENOTEMPTY` in `update_changelog_rake_spec.rb` that reddened master at `4cefb1b` and hit PR #193's `rails_6_1` job earlier. Both passed on re-run, which is what makes it a flake rather than a regression.

## Root cause

`init_git_repo!` runs `git commit`, which triggers git's **background** auto-maintenance. That process creates and deletes `.git/objects/maintenance.lock` while `Dir.mktmpdir`'s cleanup is walking the tree — cleanup stats a path that vanishes underneath it (`ENOENT`), leaves the directory non-empty, and `rmdir` then raises `ENOTEMPTY`.

```
Errno::ENOTEMPTY: Directory not empty @ dir_s_rmdir - /tmp/d20260908-2112-22lbqw
Caused by: Errno::ENOENT: .../.git/objects/maintenance.lock
```

It surfaces on whichever of the four `Dir.mktmpdir` blocks loses the race — `:51` on PR #193, `:102` on master — which is why it looked like two different failures.

## Fix

Set `maintenance.auto=false` and `gc.auto=0` in the fixture repo. `gc.auto` alone is not sufficient on modern git; `maintenance.auto` is the setting that governs the post-command background run.

`init_git_repo!` in this file is the only `git init` site in the suite, so this one helper covers every exposed block.

## Verification

- Affected spec run 5x consecutively: 13 examples, 0 failures each.
- Full gate `bundle exec rake`: 181 examples, 0 failures.
- Confirmed both config values actually take in a scratch repo.

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved changelog test reliability by disabling automatic Git maintenance and garbage collection in temporary test repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->